### PR TITLE
Add in HTTP/HTTPS selection at resource creation time

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ To use this resource plugin:
 
   irods@hostname $ iadmin mkresc compResc compound
   irods@hostname $ iadmin mkresc cacheResc unixfilesystem <hostname>:</full/path/to/Vault>
-  irods@hostname $ iadmin mkresc archiveResc s3 <hostname>:/<s3BucketName>/irods/Vault "S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE=</full/path/to/AWS.keypair>;S3_RETRY_COUNT=<num reconn tries>;S3_WAIT_TIME_SEC=<wait between retries>"
+  irods@hostname $ iadmin mkresc archiveResc s3 <hostname>:/<s3BucketName>/irods/Vault "S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE=</full/path/to/AWS.keypair>;S3_RETRY_COUNT=<num reconn tries>;S3_WAIT_TIME_SEC=<wait between retries>;S3_PROTO=HTTP"
   irods@hostname $ iadmin addchildtoresc compResc cacheResc cache
   irods@hostname $ iadmin addchildtoresc compResc archiveResc archive
   irods@hostname $ iput -R compResc foo.txt


### PR DESCRIPTION
Howdy,

There are several different on-prem object stores that speak S3 (Openstack Swift, etc.) now, besides Amazon's.  Since these stores are on a private network/VLAN, unencrypted HTTP connections are sometimes used instead of HTTPS.

The small change here adds a per-resource configurable parameter, S3_PROTO, which lets the administrator choose HTTP or HTTPS at resource creation time.  It defaults back to the original behavior when nothing is specified (HTTPS), so it should be 100% backward compatible with any existing installations.

Would you consider merging this option into your main tree?

Thanks,
-Earle F. Philhower, III