### PR TITLE
Add multithreaded, multipart upload support

### DIFF
--- a/README
+++ b/README
@@ -43,3 +43,5 @@ To control multipart uploads, add the resource variables "S3_MPU_CHUNK" and "S3_
 To ensure end-to-end data integrity, MD5 checksums can be calculated and used for S3 uploads.  Note that this requires 2x the disk IO (because the file must first be read to calculate the MD5 before the S3 upload can start) and a corresponding increase in CPU usage
 S3_ENABLE_MD5=[0|1]  (default is 0, off)
 
+S3 server side encryption can be enabled using the parameter S3_SERVER_ENCRYPT=[0|1] (default=0=off).  This is not the same as HTTPS, and implies that the data will be stored on disk encrypted.  To encrypt during the network transport to S3, please use S3_PROTO=HTTPS (the default)
+

--- a/README
+++ b/README
@@ -23,7 +23,7 @@ To use this resource plugin:
 
   irods@hostname $ iadmin mkresc compResc compound
   irods@hostname $ iadmin mkresc cacheResc unixfilesystem <hostname>:</full/path/to/Vault>
-  irods@hostname $ iadmin mkresc archiveResc s3 <hostname>:/<s3BucketName>/irods/Vault "S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE=</full/path/to/AWS.keypair>;S3_RETRY_COUNT=<num reconn tries>;S3_WAIT_TIME_SEC=<wait between retries>;S3_PROTO=HTTP"
+  irods@hostname $ iadmin mkresc archiveResc s3 <hostname>:/<s3BucketName>/irods/Vault "S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE=</full/path/to/AWS.keypair>;S3_RETRY_COUNT=<num reconn tries>;S3_WAIT_TIME_SEC=<wait between retries>;S3_PROTO=<HTTP|HTTPS>"
   irods@hostname $ iadmin addchildtoresc compResc cacheResc cache
   irods@hostname $ iadmin addchildtoresc compResc archiveResc archive
   irods@hostname $ iput -R compResc foo.txt

--- a/README
+++ b/README
@@ -32,3 +32,11 @@ The AWS/S3 keypair file should have two values (Access Key ID and Secret Access 
 
   AKDJFH4KJHFCIOBJ5SLK
   rlgjolivb7293r928vu98n498ur92jfgsdkjfh8e
+
+You may specify more than one host:IP as the S3_DEFAULT_HOSTNAME by listing them with a comma (,) between them:
+ex:  S3_DEFAULT_HOSTNAME=192.168.122.128:443,192.168.122.129:443,192.168.122.130:443
+
+To control multipart uploads, add the resource variables "S3_MPU_CHUNK" and "S3_MPU_THREADS" to the creation line.
+* S3_MPU_CHUNK is the size of each part to be uploaded in parallel (in MB, default is 5MB).  Objects smaller than this will be uploaded with standard PUTs.
+* S3_MPU_THREADS is the number of parts to upload in parallel (only under Linux, default is 10).  On non-Linux OSes, this parameter is ignored and multipart uploads are performed sequentially.
+

--- a/README
+++ b/README
@@ -40,3 +40,6 @@ To control multipart uploads, add the resource variables "S3_MPU_CHUNK" and "S3_
 * S3_MPU_CHUNK is the size of each part to be uploaded in parallel (in MB, default is 5MB).  Objects smaller than this will be uploaded with standard PUTs.
 * S3_MPU_THREADS is the number of parts to upload in parallel (only under Linux, default is 10).  On non-Linux OSes, this parameter is ignored and multipart uploads are performed sequentially.
 
+To ensure end-to-end data integrity, MD5 checksums can be calculated and used for S3 uploads.  Note that this requires 2x the disk IO (because the file must first be read to calculate the MD5 before the S3 upload can start) and a corresponding increase in CPU usage
+S3_ENABLE_MD5=[0|1]  (default is 0, off)
+

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -19,10 +19,13 @@ class Test_Compound_with_S3_Resource(ResourceSuite, ChunkyDevTest, unittest.Test
         hostname = lib.get_hostname()
         with lib.make_session_for_existing_admin() as admin_session:
             keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'
+            bucketname=os.environ.get('S3BUCKET', 'irods-ci')
+            s3params='S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE='+keypairfile+';S3_RETRY_COUNT=15;S3_WAIT_TIME_SEC=1;S3_PROTO=HTTPS;S3_MPU_CHUNK=10;S3_MPU_THREADS=4'
+            s3params=os.environ.get('S3PARAMS', s3params);
             admin_session.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', stdin_string='yes\n')
             admin_session.assert_icommand("iadmin mkresc demoResc compound", 'STDOUT_SINGLELINE', 'compound')
             admin_session.assert_icommand("iadmin mkresc cacheResc 'unixfilesystem' "+hostname+":/var/lib/irods/cacheRescVault", 'STDOUT_SINGLELINE', 'cacheResc')
-            admin_session.assert_icommand('iadmin mkresc archiveResc s3 '+hostname+':/irods-ci/irods/Vault "S3_DEFAULT_HOSTNAME=s3.amazonaws.com;S3_AUTH_FILE='+keypairfile+';S3_RETRY_COUNT=15;S3_WAIT_TIME_SEC=1"', 'STDOUT_SINGLELINE', 'archiveResc')
+            admin_session.assert_icommand('iadmin mkresc archiveResc s3 '+hostname+':/'+bucketname+'/irods/Vault "'+s3params+'"', 'STDOUT_SINGLELINE', 'archiveResc')
             admin_session.assert_icommand("iadmin addchildtoresc demoResc cacheResc cache")
             admin_session.assert_icommand("iadmin addchildtoresc demoResc archiveResc archive")
         super(Test_Compound_with_S3_Resource, self).setUp()

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -4,7 +4,7 @@ SRCS = libirods_s3.cpp
 
 HEADERS = libirods_s3.hpp
 
-EXTRALIBS = /usr/lib/libirods_client.a -ls3 -lxml2 -lcurl
+EXTRALIBS = /usr/lib/libirods_client_plugins.a -ls3 -lxml2 -lcurl
 
 EXTRAINCS = 
 

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -4,7 +4,7 @@ SRCS = libirods_s3.cpp
 
 HEADERS = libirods_s3.hpp
 
-EXTRALIBS = /usr/lib/libirods_client.a /usr/lib/irods/externals/libs3.a -lxml2 -lcurl
+EXTRALIBS = /usr/lib/libirods_client.a -ls3 -lxml2 -lcurl
 
 EXTRAINCS = 
 

--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -101,7 +101,7 @@ extern "C" {
     static bool S3Initialized = false; // so we only initialize the s3 library once
     static std::vector<char *> g_hostname;
     static int g_hostnameIdx = 0;
-    static boost::mutex g_hostnameIdxLock; // Init'd in s3Init
+    static boost::mutex g_hostnameIdxLock;
 
 
     // Increment through all specified hostnames in the list, locking in the case
@@ -349,6 +349,11 @@ extern "C" {
                 while (std::getline(ss, item, ',')) {
                     g_hostname.push_back(strdup(item.c_str()));
                 }
+                // Because each resource operation is a new instance, randomize the starting
+                // hostname offset so we don't always hit the first in the list between different
+                // operations.
+                srand(time(NULL));
+                g_hostnameIdx = rand() % g_hostname.size();
             }
 
             size_t retry_count = 10;

--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -564,7 +564,6 @@ extern "C" {
     static volatile int mpuAbort = FALSE;   // TBD: On part upload failure, abort and destroy upload
 
     /******************* Multipart Initialization Callbacks *****************************/
-    /* callbackData = upload_manager_t*                                                 */
 
     /* Captures the upload_id returned and stores it away in our data structure */
     static S3Status mpuInitXmlCB (
@@ -594,7 +593,6 @@ extern "C" {
 
 
     /******************* Multipart Put Callbacks *****************************/
-    /* callbackData = multipart_data_t*                                      */
 
     /* Upload data from the part, use the plain callback_data reader */
     static int mpuPartPutDataCB (
@@ -739,7 +737,7 @@ extern "C" {
                 bucketContext.hostName = s3GetHostname(); // Safe to do, this is a local copy of the data structure
                 S3_upload_part(&bucketContext, mpuKey, NULL, &putObjectHandler, seq, mpuUploadId, partData->put_object_data.contentLength, 0, partData);
                 retry_cnt++;
-                snprintf(buff, 255, "Multipart:  End part %d, key %s, uploadid %s, offset %ld, len %d", (int)seq, mpuKey, mpuUploadId, (long)partData->put_object_data.offset, (int)partData->put_object_data.contentLength);
+                snprintf(buff, 255, "Multipart:  End part %d, key %s, uploadid %s, offset %ld", (int)seq, mpuKey, mpuUploadId, (long)partData->put_object_data.offset);
                 rodsLog( LOG_NOTICE, buff);
             } while ((partData->status != S3StatusOK) && (retry_cnt < RETRY_COUNT) && !mpuAbort);
             if (partData->status != S3StatusOK) {
@@ -982,6 +980,10 @@ extern "C" {
                         }
 
                         if (!mpuAbort) {
+                            char buff[256];
+                            snprintf(buff, 255, "Multipart:  Completing key %s", key.c_str());
+                            rodsLog( LOG_NOTICE, buff );
+
                             int i;
                             strcpy(manager.xml, "<CompleteMultipartUpload>\n");
                             manager.remaining = strlen(manager.xml);

--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -936,7 +936,6 @@ extern "C" {
                             };
 
                             data.keyCount = 0;
-                            data.allDetails = 1;
 
                             S3_list_bucket(&bucketContext, key.c_str(), NULL,
                                            NULL, 1, 0, &listBucketHandler, &data);

--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -159,14 +159,14 @@ extern "C" {
         char *buffer,
         void *callbackData)
     {
-        put_object_callback_data *data = (put_object_callback_data *) callbackData;
+        callback_data_t *data = (callback_data_t *) callbackData;
         int length;    
         int ret = 0;
         
         if (data->contentLength) {
             int length = ((data->contentLength > (unsigned) bufferSize) ?
                           (unsigned) bufferSize : data->contentLength);
-            ret = fread(buffer, 1, length, data->infile);
+            ret = fread(buffer, 1, length, data->fd);
         }
         data->contentLength -= ret;
         return ret;

--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -669,7 +669,7 @@ extern "C" {
         S3AbortMultipartUploadHandler abortHandler = { { mpuCancelRespPropCB, mpuCancelRespCompCB } };
         S3Status status;
 
-        rodsLog( LOG_ERROR, "Aborting multipart upload");
+        printf("Aborting multipart upload:  key=%s, id=%s\n", key, upload_id);
         S3_abort_multipart_upload(bucketContext, key, upload_id, &abortHandler);
         if (status != S3StatusOK) {
             std::stringstream msg;
@@ -719,7 +719,6 @@ extern "C" {
                 S3_upload_part(&bucketContext, mpuKey, NULL, &putObjectHandler, seq, mpuUploadId, partData->put_object_data.contentLength, 0, partData);
                 retry_cnt++;
                 rodsLog( LOG_ERROR, "Multipart:  End part" );
-printf("seq %d, mpuabort: %d\n", seq, mpuAbort);
             } while ((partData->status != S3StatusOK) && (retry_cnt < RETRY_COUNT) && !mpuAbort);
             if (partData->status != S3StatusOK) {
                 std::stringstream msg;
@@ -853,7 +852,7 @@ printf("seq %d, mpuabort: %d\n", seq, mpuAbort);
                         multipart_data_t partData;
                         int partContentLength = 0;
 
-                        manager.etags = (char**)malloc(sizeof(char*) * totalSeq);
+                        manager.etags = (char**)calloc(sizeof(char*) * totalSeq, 1);
 
                         retry_cnt = 0;
                         do {
@@ -1003,10 +1002,10 @@ printf("seq %d, mpuabort: %d\n", seq, mpuAbort);
                             }
                         }
                         if (mpuAbort && manager.upload_id) {
-rodsLog(LOG_ERROR, "Cancelling u/l");
-                            mpuCancel( &bucketContext, _s3ObjName.c_str(), manager.upload_id );
+                            rodsLog(LOG_ERROR, "Cancelling u/l");
+                            mpuCancel( &bucketContext, key.c_str(), manager.upload_id );
                         }
-rodsLog(LOG_ERROR, "Freeing up memory"); 
+                        rodsLog(LOG_ERROR, "Freeing up memory"); 
                         // Clean up memory
                         if (manager.xml) free(manager.xml);
                         if (manager.upload_id) free(manager.upload_id);

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -25,10 +25,7 @@ typedef struct callback_data
 {
     int fd;
     rodsLong_t contentLength, originalContentLength;
-    int isTruncated;
-    char nextMarker[1024];
     int keyCount;
-    int allDetails;
     s3Stat_t s3Stat;    /* should be a pointer if keyCount > 1 */
     int status;
 } callback_data_t;

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -23,7 +23,7 @@ typedef struct s3Stat
 
 typedef struct callback_data
 {
-    FILE *fd;
+    int fd;
     rodsLong_t contentLength, originalContentLength;
     int isTruncated;
     char nextMarker[1024];

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -24,7 +24,7 @@ typedef struct s3Stat
 typedef struct callback_data
 {
     int fd;
-    off_t offset;       /* For multiple upload */
+    long offset;       /* For multiple upload */
     rodsLong_t contentLength, originalContentLength;
     S3Status status;
     int keyCount;
@@ -39,8 +39,8 @@ typedef struct upload_manager
 
     /* Below used for the upload completion command, need to send in XML */
     char *xml;
-    int remaining;
-    int offset;
+    long remaining;
+    long offset;
 
     S3Status status;
 } upload_manager_t;

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -52,6 +52,7 @@ typedef struct multipart_data
     upload_manager_t *manager;     /* To update w/the MD5 returned */
 
     S3Status status;
+    bool enable_md5;
 } multipart_data_t;
 
 #endif // _LIBEIRODS_S3_H_

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -26,9 +26,10 @@ typedef struct callback_data
     int fd;
     off_t offset;       /* For multiple upload */
     rodsLong_t contentLength, originalContentLength;
+    S3Status status;
     int keyCount;
     s3Stat_t s3Stat;    /* should be a pointer if keyCount > 1 */
-    int status;
+    //int status;
 } callback_data_t;
 
 typedef struct upload_manager
@@ -40,6 +41,8 @@ typedef struct upload_manager
     char *xml;
     int remaining;
     int offset;
+
+    S3Status status;
 } upload_manager_t;
 
 typedef struct multipart_data
@@ -47,6 +50,8 @@ typedef struct multipart_data
     int seq;                       /* Sequence number, i.e. which part */
     callback_data put_object_data; /* File being uploaded */
     upload_manager_t *manager;     /* To update w/the MD5 returned */
+
+    S3Status status;
 } multipart_data_t;
 
 #endif // _LIBEIRODS_S3_H_

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -33,10 +33,4 @@ typedef struct callback_data
     int status;
 } callback_data_t;
 
-typedef struct put_object_callback_data
-{
-    FILE *infile;
-    uint64_t contentLength, originalContentLength;
-} put_object_callback_data;
-
 #endif // _LIBEIRODS_S3_H_

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -53,6 +53,7 @@ typedef struct multipart_data
 
     S3Status status;
     bool enable_md5;
+    bool server_encrypt;
 } multipart_data_t;
 
 #endif // _LIBEIRODS_S3_H_

--- a/s3/libirods_s3.hpp
+++ b/s3/libirods_s3.hpp
@@ -24,10 +24,29 @@ typedef struct s3Stat
 typedef struct callback_data
 {
     int fd;
+    off_t offset;       /* For multiple upload */
     rodsLong_t contentLength, originalContentLength;
     int keyCount;
     s3Stat_t s3Stat;    /* should be a pointer if keyCount > 1 */
     int status;
 } callback_data_t;
+
+typedef struct upload_manager
+{
+    char *upload_id;    /* Returned from S3 on MP begin */
+    char **etags;       /* Each upload part's MD5 */
+
+    /* Below used for the upload completion command, need to send in XML */
+    char *xml;
+    int remaining;
+    int offset;
+} upload_manager_t;
+
+typedef struct multipart_data
+{
+    int seq;                       /* Sequence number, i.e. which part */
+    callback_data put_object_data; /* File being uploaded */
+    upload_manager_t *manager;     /* To update w/the MD5 returned */
+} multipart_data_t;
 
 #endif // _LIBEIRODS_S3_H_


### PR DESCRIPTION
Howdy Jason,

As promised, here is the updated code.  The diffs are mostly related to multipart/multithread handling in the upload stage, but to do that required removing the global status variable.  So you'll see lots of "unrelated" function edits.  It also needs the latest libs3 to be pulled in (or remove libs3 from irods directories completely if there's no real main trunk need).

A minor addition to hostname handling is the support of multiple hosts, comma separated.  This is needed for some S3 appliances where you have multiple control heads (but a consistent view of things behind the scenes).  Amazon has HW load balancers on s3.amazonaws.com to do this transparently to the user, but this allows for explicit SW load balancing for appliances w/o that HW in front of them.  If only one host (or none) are specified, there is no change in behavior.

The test .py file now allows environment overrides, but defaults to your original settings so it should not affect your CI system at all.  This allows me to run against my own test S3 appliance w/o patching the code.

Other stuff was just cleanup:

There were 2 structs{} defined as callback values in the header file, and both were used by callback functions....but only the first one was actually created/written to by the main function.  Because the first few variables matched in size and order it worked....until I had to start adding values to the struct and alignments shifted.  I cleaned that up and worked through things to ensure every callback is passed the proper struct type it expects, and no "lucky" aliasing is needed.

There was also some dead code.  A couple #ifdef (linux_platform ) (which actually never was defined in the build) could go, as well as many spots where the S3 operation functions tried to get the s3_hostname, but never actually used it.

Thanks,
-EFP3