### PR TITLE
Issue 1855

### DIFF
--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -2174,6 +2174,10 @@ irods::error s3FileRenamePlugin( irods::plugin_context& _ctx,
                                  object->physical_path().c_str());
         }
     }
+
+    // issue 1855 (irods issue 4326) - resources must now set physical path
+    object->physical_path(_new_file_name);
+
     return result;
 } // s3FileRenamePlugin
 


### PR DESCRIPTION
[1855] Test move when decoupled naming when vault path is just the bucket name.  Add setting the physical_path when not using decoupled naming.