### PR TITLE
[1903] Fixed the stomping of error message (master)

### DIFF
--- a/s3/libirods_s3.cpp
+++ b/s3/libirods_s3.cpp
@@ -514,9 +514,6 @@ irods::error readS3AuthInfo (
         return result;
     }
 
-    std::string error_str =  boost::str(boost::format("[resource_name=%s] Unknown error in authorization file.") % resource_name.c_str()); 
-
-    result = ERROR( SYS_CONFIG_FILE_ERR, error_str.c_str());
     return result;
 }
 


### PR DESCRIPTION
Fixed the stomping of the detailed error message when the keypair file is not found.