### PR TITLE
Issue 1948

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -82,9 +82,9 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         s3_client.make_bucket(self.s3bucketname, location=self.s3region)
 
         self.testresc = "TestResc"
-        self.testvault = "/tmp/" + self.testresc
+        self.testvault = "/" + self.testresc
         self.anotherresc = "AnotherResc"
-        self.anothervault = "/tmp/" + self.anotherresc
+        self.anothervault = "/" + self.anotherresc
 
         self.s3_context = 'S3_DEFAULT_HOSTNAME=' + self.s3endPoint
         self.s3_context += ';S3_AUTH_FILE=' + self.keypairfile
@@ -96,6 +96,7 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         self.s3_context += ';HOST_MODE=cacheless_attached'
         self.s3_context += ';S3_ENABLE_MD5=1'
         self.s3_context += ';S3_ENABLE_MPU=' + str(self.s3EnableMPU)
+        self.s3_context += ';S3_CACHE_DIR=/var/lib/irods'
 
         try:
             self.s3_context += ';S3_SERVER_ENCRYPT=' + str(self.s3sse)
@@ -105,7 +106,7 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
 
         self.admin.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
 
-        self.admin.assert_icommand("iadmin mkresc demoResc s3 " + hostname + ":/" + self.s3bucketname + "/tmp/demoResc " + self.s3_context, 'STDOUT_SINGLELINE', 's3')
+        self.admin.assert_icommand("iadmin mkresc demoResc s3 " + hostname + ":/" + self.s3bucketname + "/demoResc " + self.s3_context, 'STDOUT_SINGLELINE', 's3')
 
         self.admin.assert_icommand(
             ['iadmin', "mkresc", self.testresc, 's3', hostname + ":/" + self.s3bucketname + self.testvault, self.s3_context], 'STDOUT_SINGLELINE', 's3')
@@ -790,10 +791,10 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         lib.execute_command("cat %s %s > %s" % (filename, filename, doublefile), use_unsafe_shell=True)
 
         # assertions
-        self.admin.assert_icommand("iadmin mkresc thirdresc s3 %s:/%s/tmp/%s/thirdrescVault %s" %
+        self.admin.assert_icommand("iadmin mkresc thirdresc s3 %s:/%s/%s/thirdrescVault %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")   # create third resource
 
-        self.admin.assert_icommand("iadmin mkresc fourthresc s3 %s:/%s/tmp/%s/fourthrescVault %s" %
+        self.admin.assert_icommand("iadmin mkresc fourthresc s3 %s:/%s/%s/fourthrescVault %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")  # create fourth resource
 
         self.admin.assert_icommand("ils -L " + filename, 'STDERR_SINGLELINE', "does not exist")              # should not be listed
@@ -873,7 +874,7 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         hostname = lib.get_hostname()
         hostuser = getpass.getuser()
         # assertions
-        self.admin.assert_icommand("iadmin mkresc thirdresc s3 %s:/%s/tmp/%s/thirdrescVault %s" %
+        self.admin.assert_icommand("iadmin mkresc thirdresc s3 %s:/%s/%s/thirdrescVault %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")  # create third resource
 
 
@@ -1630,11 +1631,11 @@ OUTPUT ruleExecOut
 
             # create two s3 resources in repl node
             self.admin.assert_icommand("iadmin mkresc s3repl replication".format(**locals()), 'STDOUT_SINGLELINE', "replication")
-            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/tmp/%s/s3resc1 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
-            self.admin.assert_icommand("iadmin mkresc s3resc2 s3 %s:/%s/tmp/%s/s3resc2 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc2 s3 %s:/%s/%s/s3resc2 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
-            self.admin.assert_icommand("iadmin mkresc s3resc3 s3 %s:/%s/tmp/%s/s3resc3 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc3 s3 %s:/%s/%s/s3resc3 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc1", 'EMPTY')
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc2", 'EMPTY')
@@ -1690,11 +1691,11 @@ OUTPUT ruleExecOut
 
             # create two s3 resources in repl node
             self.admin.assert_icommand("iadmin mkresc s3repl replication".format(**locals()), 'STDOUT_SINGLELINE', "replication")
-            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/tmp/%s/s3resc1 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
-            self.admin.assert_icommand("iadmin mkresc s3resc2 s3 %s:/%s/tmp/%s/s3resc2 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc2 s3 %s:/%s/%s/s3resc2 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
-            self.admin.assert_icommand("iadmin mkresc s3resc3 s3 %s:/%s/tmp/%s/s3resc3 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc3 s3 %s:/%s/%s/s3resc3 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc1", 'EMPTY')
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc2", 'EMPTY')
@@ -1749,7 +1750,7 @@ OUTPUT ruleExecOut
             hostuser = getpass.getuser()
 
             # create two s3 resources in repl node
-            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/tmp/%s/s3resc1 %s" %
+            self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
 
             # create and put file

--- a/s3/s3_transport/include/s3_transport.hpp
+++ b/s3/s3_transport/include/s3_transport.hpp
@@ -879,6 +879,8 @@ namespace irods::experimental::io::s3_transport
             }
 
             // remove cache file
+            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] removing cache file %s\n",
+                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), cache_file_path_.c_str());
             std::remove(cache_file_path_.c_str());
 
             // set cache file download flag to NOT_STARTED
@@ -1086,6 +1088,8 @@ namespace irods::experimental::io::s3_transport
                         bf::path parent_path = cache_file.parent_path();
 
                         try {
+                            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] Creating parent_path  %s\n",
+                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), parent_path.string().c_str());
                             boost::filesystem::create_directories(parent_path);
                         } catch (boost::filesystem::filesystem_error& e) {
                             rodsLog(LOG_ERROR, "%s:%d (%s) [[%lu]] Could not create parent directories for cache file.  %s\n",
@@ -1109,18 +1113,18 @@ namespace irods::experimental::io::s3_transport
                         // try opening for read and write, if it fails create then open for read/write
                         cache_fstream_.open(cache_file_path_.c_str(), mode | std::ios_base::in | std::ios_base::out);
                         if (!cache_fstream_.is_open()) {
-                            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] opened cache file with create [trunc_flag=%d]\n", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), trunc_flag);
+                            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] opened cache file %s with create [trunc_flag=%d]\n", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
                             // file may not exist, open with std::ios_base::out to create then with in/out
-                            cache_fstream_.open(cache_file_path_.c_str(), mode | std::ios_base::out);
+                            cache_fstream_.open(cache_file_path_.c_str(), std::ios_base::out);
                             cache_fstream_.close();
                             cache_fstream_.open(cache_file_path_.c_str(), mode | std::ios_base::in | std::ios_base::out);
                         } else {
-                            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] opened cache file [trunc_flag=%d]\n", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), trunc_flag);
+                            rodsLog(config_.debug_log_level, "%s:%d (%s) [[%lu]] opened cache file %s [trunc_flag=%d]\n", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
                         }
 
                         if (!cache_fstream_ || !cache_fstream_.is_open()) {
-                            rodsLog(LOG_ERROR, "%s:%d (%s) [[%lu]] Failed to open cache file %s\n",
-                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), cache_file_path_.c_str());
+                            rodsLog(LOG_ERROR, "%s:%d (%s) [[%lu]] Failed to open cache file %s, error=%s\n",
+                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), cache_file_path_.c_str(), strerror(errno));
                             this->critical_error_encountered_ = true;
                             return_value = false;
                         }

--- a/s3/s3_transport/unit_tests/CMakeLists.txt
+++ b/s3/s3_transport/unit_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ project(unit_tests LANGUAGES C CXX)
 
 find_package(IRODS 4.2.8 EXACT REQUIRED)
 
-set(IRODS_EXTERNALS_FULLPATH_S3 "/opt/irods-externals/libs3a30e55e8-1/")
+set(IRODS_EXTERNALS_FULLPATH_S3 "/opt/irods-externals/libs34e684077-0/")
 
 message(STATUS "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}")
 message(STATUS "IRODS_EXTERNALS_FULLPATH_S3=${IRODS_EXTERNALS_FULLPATH_S3}")

--- a/s3/s3_transport/unit_tests/cmake/test_config/irods_s3_transport.cmake
+++ b/s3/s3_transport/unit_tests/cmake/test_config/irods_s3_transport.cmake
@@ -1,0 +1,24 @@
+set(IRODS_TEST_TARGET irods_s3_transport)
+
+set(IRODS_TEST_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/src/test_s3_transport.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/../src/s3_transport.cpp)
+
+                        set(IRODS_TEST_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                            ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                            ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+                            ${IRODS_EXTERNALS_FULLPATH_JSON}/include
+                            ${IRODS_EXTERNALS_FULLPATH_S3}/include
+                            /usr/include/libxml2
+                            ${IRODS_INCLUDE_DIRS}
+                            )
+
+set(IRODS_TEST_LINK_LIBRARIES irods_common
+                              irods_client
+                              c++abi
+                              rt
+                              ${IRODS_EXTERNALS_FULLPATH_S3}/lib/libs3.so
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+                              ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_thread.so
+                              )

--- a/s3/s3_transport/unit_tests/cmake/utils.cmake
+++ b/s3/s3_transport/unit_tests/cmake/utils.cmake
@@ -1,0 +1,10 @@
+# utils.cmake
+# ~~~~~~~~~~~
+# Defines helper functions and other utilities for testing.
+
+function(unset_irods_test_variables)
+    unset(IRODS_TEST_TARGET)
+    unset(IRODS_TEST_SOURCE_FILES)
+    unset(IRODS_TEST_INCLUDE_PATH)
+    unset(IRODS_TEST_LINK_LIBRARIES)
+endfunction()

--- a/s3/s3_transport/unit_tests/src/test_s3_transport.cpp
+++ b/s3/s3_transport/unit_tests/src/test_s3_transport.cpp
@@ -410,6 +410,7 @@ void read_write_on_file(const char *hostname,
     s3_config.put_repl_flag = false;
     s3_config.debug_log_level = LOG_NOTICE;
     s3_config.region_name = "us-east-1";
+    s3_config.cache_directory = ".";
 
     s3_transport tp1{s3_config};
     dstream ds1{tp1, std::string(object_prefix)+filename, open_modes};


### PR DESCRIPTION
Changes:

# Issue 1948:

1.  Added support for S3_CACHE_DIR.  Fixed open mode for decoupled naming.
2.  Used the irods::CFG_RE_CACHE_SALT_KW and the resource ID as a subdirectory of this cache directory similar to previous versions.
3.  Removed "/tmp/" from vault path in test cases because that confused me and wasn't necessary.
4.  Added some debug logging.

# Issue 1951:

1.  Added cmake directory in unit test cases.
2.  Updated libs3 version in unit test CMakeLists.txt.