### PR TITLE
[irods/irods_5937] auto-generate package filename and add package revision string to package version (master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ target_include_directories(
   ${IRODS_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/s3/s3_transport/include
   ${IRODS_EXTERNALS_FULLPATH_BOOST}/include
+  ${IRODS_EXTERNALS_FULLPATH_FMT}/include
   ${IRODS_EXTERNALS_FULLPATH_JSON}/include
   ${IRODS_EXTERNALS_FULLPATH_S3}/include
   ${CURL_INCLUDE_DIRS}


### PR DESCRIPTION
This PR also fixes the `-Wno-error=deprecated-copy` flag being passed for compilers that do not support `-Wdeprecated-copy`