### PR TITLE
Add tests for data objects stuck in locked status, prevent nullptr dereference (main)

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -56,10 +56,13 @@ def download_and_start_minio_server():
 
     root_username = ''.join(random.choice(string.ascii_letters) for i in list(range(10)))
     root_password = ''.join(random.choice(string.ascii_letters) for i in list(range(10)))
+    keypair_path = '/var/lib/irods/minio.keypair'
 
-    with open('/var/lib/irods/minio.keypair', 'w') as f:
+    with open(keypair_path, 'w') as f:
         f.write('%s\n' % root_username)
         f.write('%s\n' % root_password)
+
+    shutil.chown(keypair_path, user='irods', group='irods')
 
     os.environ['MINIO_ROOT_USER'] = root_username
     os.environ['MINIO_ROOT_PASSWORD'] = root_password

--- a/packaging/resource_suite_s3_cache.py
+++ b/packaging/resource_suite_s3_cache.py
@@ -669,6 +669,206 @@ class Test_S3_Cache_Base(ResourceSuite, ChunkyDevTest):
             self.user0.run_icommand(['irm', '-f', logical_path])
 
 
+    def test_iput_with_invalid_secret_key_and_overwrite__issue_6154(self):
+        replica_number_in_s3 = 1
+        filename = 'test_iput_with_invalid_secret_key__issue_6154'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        physical_path = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        access_key = 'nopenopenopenope'
+        secret_key = 'wrongwrongwrong!'
+
+        try:
+            lib.make_file(physical_path, file_size_in_bytes)
+
+            with lib.file_backed_up(self.keypairfile):
+                # Invalidate the existing keypairfile so that the S3 resource cannot communicate with the S3 backend.
+                with open(self.keypairfile, 'w') as f:
+                    f.write('{}\n{}'.format(access_key, secret_key))
+
+                # Put the physical file, which should fail, leaving a data object with a stale replica. The main
+                # purpose of this test is to ensure that the system is in a state from which it can recover.
+                self.user0.assert_icommand(['iput', physical_path, logical_path], 'STDERR', 'S3_PUT_ERROR')
+                self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+                self.assertEqual(str(0), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Now overwrite the data object with wild success. This is here to ensure that things are back to normal.
+            self.user0.assert_icommand(['iput', '-f', physical_path, logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+        finally:
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            for replica_number in [0, 1]:
+                self.admin.run_icommand([
+                    'iadmin', 'modrepl',
+                    'logical_path', logical_path,
+                    'replica_number', str(replica_number),
+                    'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+
+
+    def test_iput_with_invalid_secret_key_and_remove__issue_6154(self):
+        replica_number_in_s3 = 1
+        filename = 'test_iput_with_invalid_secret_key__issue_6154'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        physical_path = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        access_key = 'nopenopenopenope'
+        secret_key = 'wrongwrongwrong!'
+
+        try:
+            lib.make_file(physical_path, file_size_in_bytes)
+
+            with lib.file_backed_up(self.keypairfile):
+                # Invalidate the existing keypairfile so that the S3 resource cannot communicate with the S3 backend.
+                with open(self.keypairfile, 'w') as f:
+                    f.write('{}\n{}'.format(access_key, secret_key))
+
+                # Put the physical file, which should fail, leaving a data object with a stale replica. The main
+                # purpose of this test is to ensure that the system is in a state from which it can recover.
+                self.user0.assert_icommand(['iput', physical_path, logical_path], 'STDERR', 'S3_PUT_ERROR')
+                self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+                self.assertEqual(str(0), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+                # debugging
+                self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+                # Attempt to remove the data object, which fails due to the invalid secret key.
+                self.user0.assert_icommand(['irm', '-f', logical_path], 'STDERR', 'S3_FILE_UNLINK_ERR')
+                self.assertTrue(lib.replica_exists(self.user0, logical_path, replica_number_in_s3))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Attempt to remove the data object, which succeeds because the S3 object doesn't exist anyway.
+            self.user0.assert_icommand(['irm', '-f', logical_path])
+            self.assertFalse(lib.replica_exists(self.user0, logical_path, 0))
+            self.assertFalse(lib.replica_exists(self.user0, logical_path, replica_number_in_s3))
+
+        finally:
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            for replica_number in [0, 1]:
+                self.admin.run_icommand([
+                    'iadmin', 'modrepl',
+                    'logical_path', logical_path,
+                    'replica_number', str(replica_number),
+                    'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+
+
+    def test_iput_and_replicate_with_invalid_secret_key__issue_6154(self):
+        replica_number_in_s3 = 2
+        filename = 'test_iput_and_replicate_with_invalid_secret_key__issue_6154'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        physical_path = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        access_key = 'nopenopenopenope'
+        secret_key = 'wrongwrongwrong!'
+        test_resc = 'test_resc'
+
+        try:
+            lib.create_ufs_resource(test_resc, self.admin)
+
+            lib.make_file(physical_path, file_size_in_bytes)
+
+            # Put the physical file to the test resource. The test will replicate to S3.
+            self.user0.assert_icommand(['iput', '-R', test_resc, physical_path, logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+
+            with lib.file_backed_up(self.keypairfile):
+                # Invalidate the existing keypairfile so that the S3 resource cannot communicate with the S3 backend.
+                with open(self.keypairfile, 'w') as f:
+                    f.write('{}\n{}'.format(access_key, secret_key))
+
+                # Replicate the data object to the compound resource hierarchy. The replica in the cache should be good
+                # and the replica in the archive should be stale due to the invalid secret key.
+                self.user0.assert_icommand(['irepl', logical_path], 'STDERR', 'S3_PUT_ERROR')
+                self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 1))
+                self.assertEqual(str(0), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Trim the cache replica so that we can try the replication again with a good secret key.
+            self.user0.assert_icommand(['itrim', '-N1', '-n1', logical_path], 'STDOUT')
+            self.user0.assert_icommand(['itrim', '-N1', '-n', str(replica_number_in_s3), logical_path], 'STDOUT')
+            self.assertFalse(lib.replica_exists(self.user0, logical_path, 1))
+            self.assertFalse(lib.replica_exists(self.user0, logical_path, replica_number_in_s3))
+
+            # Now replicate with a good set of S3 keys and watch for success.
+            self.user0.assert_icommand(['irepl', logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 1))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+        finally:
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            for replica_number in range(0, 3):
+                self.admin.run_icommand([
+                    'iadmin', 'modrepl',
+                    'logical_path', logical_path,
+                    'replica_number', str(replica_number),
+                    'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+            lib.remove_resource(test_resc, self.admin)
+
+
+    def test_iput_and_icp_with_invalid_secret_key__issue_6154(self):
+        replica_number_in_s3 = 1
+        filename = 'test_iput_and_icp_with_invalid_secret_key__issue_6154'
+        original_logical_path = os.path.join(self.user0.session_collection, filename + '_orig')
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        physical_path = os.path.join(self.user0.local_session_dir, filename)
+        file_size_in_bytes = 10
+        access_key = 'nopenopenopenope'
+        secret_key = 'wrongwrongwrong!'
+        test_resc = 'test_resc'
+
+        try:
+            lib.create_ufs_resource(test_resc, self.admin)
+
+            lib.make_file(physical_path, file_size_in_bytes)
+
+            # Put the physical file to the test resource. The test will copy to S3.
+            self.user0.assert_icommand(['iput', '-R', test_resc, physical_path, original_logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, os.path.basename(original_logical_path), 0))
+
+            with lib.file_backed_up(self.keypairfile):
+                # Invalidate the existing keypairfile so that the S3 resource cannot communicate with the S3 backend.
+                with open(self.keypairfile, 'w') as f:
+                    f.write('{}\n{}'.format(access_key, secret_key))
+
+                # Copy the physical file, which should fail, leaving a data object with a stale replica. The main
+                # purpose of this test is to ensure that the system is in a state from which it can recover.
+                self.user0.assert_icommand(['icp', original_logical_path, logical_path], 'STDERR', 'S3_PUT_ERROR')
+                self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+                self.assertEqual(str(0), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+            # debugging
+            self.user0.assert_icommand(['ils', '-L', os.path.dirname(logical_path)], 'STDOUT', filename)
+
+            # Now overwrite the data object with wild success. This is here to ensure that things are back to normal.
+            self.user0.assert_icommand(['icp', '-f', original_logical_path, logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, 0))
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+        finally:
+            self.user0.run_icommand(['irm', '-f', original_logical_path])
+            lib.remove_resource(test_resc, self.admin)
+
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            for replica_number in [0, 1]:
+                self.admin.run_icommand([
+                    'iadmin', 'modrepl',
+                    'logical_path', logical_path,
+                    'replica_number', str(replica_number),
+                    'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+
+
 class Test_S3_Cache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass'), ('bobby', 'bpass')])):
 
     def __init__(self, *args, **kwargs):

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2012,6 +2012,53 @@ OUTPUT ruleExecOut
             self.admin.assert_icommand("iadmin rmresc s3resc1", 'EMPTY')
 
 
+    def test_itouch_nonexistent_file__issue_6479(self):
+        replica_number_in_s3 = 0
+        filename = 'test_itouch_nonexistent_file__issue_6479'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+
+        try:
+            # Just itouch and ensure that the data object is created successfully.
+            self.user0.assert_icommand(['itouch', logical_path])
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+            # Ensure that the replica actually exists.
+            self.user0.assert_icommand(['iget', logical_path, '-'])
+
+        finally:
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            self.admin.run_icommand([
+                'iadmin', 'modrepl',
+                'logical_path', logical_path,
+                'replica_number', str(replica_number_in_s3),
+                'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+
+
+    def test_istream_nonexistent_file__issue_6479(self):
+        replica_number_in_s3 = 0
+        filename = 'test_istream_nonexistent_file__issue_6479'
+        logical_path = os.path.join(self.user0.session_collection, filename)
+        content = 'streamin and screamin'
+
+        try:
+            # istream to a new data object and ensure that it is created successfully.
+            self.user0.assert_icommand(['istream', 'write', logical_path], input=content)
+            self.assertEqual(str(1), lib.get_replica_status(self.user0, filename, replica_number_in_s3))
+
+            # Ensure that the replica actually contains the contents streamed into it.
+            self.user0.assert_icommand(['iget', logical_path, '-'], 'STDOUT', content)
+
+        finally:
+            # Set the replica status here so that we can remove the object even if it is stuck in the locked status.
+            self.admin.run_icommand([
+                'iadmin', 'modrepl',
+                'logical_path', logical_path,
+                'replica_number', str(replica_number_in_s3),
+                'DATA_REPL_STATUS', '0'])
+            self.user0.run_icommand(['irm', '-f', logical_path])
+
+
 class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass'), ('bobby', 'bpass')])):
 
     def __init__(self, *args, **kwargs):

--- a/s3/s3_operations.cpp
+++ b/s3/s3_operations.cpp
@@ -933,9 +933,11 @@ namespace irods_s3 {
             // to be created
             if (!data.dstream_ptr) {
                 char buff[1];
-                s3_file_write_operation(_ctx, buff, 0);
-                data = fd_data.get(fd);
-            }
+				if (const auto err = s3_file_write_operation(_ctx, buff, 0); !err.ok()) {
+					return PASS(err);
+				}
+				data = fd_data.get(fd);
+			}
 
             fd_data.remove(fd);
 


### PR DESCRIPTION
Addresses irods/irods#6154
Addresses irods/irods#6479
Addresses irods/irods#6880

Companion PR: https://github.com/irods/irods/pull/6884

Running tests now.