### PR TITLE
[2122] Reset global vars after last file closes. (4-2-stable)

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2060,7 +2060,9 @@ OUTPUT ruleExecOut
     # 3) a couple of files in the middle of the range (8MB and 16MB)
     # 4) a small file
     # 5) a file one byte less than 32MB just in case
-    def test_s3_in_replication_node__issue_2102(self):
+    #
+    # Added -k flag on iput to test issue 2122
+    def test_s3_in_replication_node__issues_2102_2122(self):
         resc_prefix = 'issue_2101'
         repl_resource_name = '%s_repl' % resc_prefix
         s3_resc1_resource_name = '%s_s3_resc1' % resc_prefix
@@ -2099,7 +2101,7 @@ OUTPUT ruleExecOut
                 lib.make_arbitrary_file(filename, file_size)
 
                 # put the file to repl_resource
-                self.user1.assert_icommand("iput -R %s %s" % (repl_resource_name, filename))
+                self.user1.assert_icommand("iput -k -R %s %s" % (repl_resource_name, filename))
 
                 # debug
                 self.user1.assert_icommand("ils -l %s" % filename, 'STDOUT_SINGLELINE', filename)

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -150,6 +150,9 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_put_get_large_file_in_repl_node(self):
         pass
 
+    @unittest.skip('test does not work in decoupled because we are using same bucket for multiple resources')
+    def test_s3_in_replication_node__issues_2102_2122(self):
+        pass
 
 class Test_S3_NoCache_Glacier(Test_S3_NoCache_Glacier_Base, unittest.TestCase):
 

--- a/packaging/test_irods_resource_plugin_s3_ceph.py
+++ b/packaging/test_irods_resource_plugin_s3_ceph.py
@@ -64,4 +64,6 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_put_get_large_file_in_repl_node(self):
         pass
 
-
+    @unittest.skip('test does not work in decoupled because we are using same bucket for multiple resources')
+    def test_s3_in_replication_node__issues_2102_2122(self):
+        pass

--- a/packaging/test_irods_resource_plugin_s3_fujifilm.py
+++ b/packaging/test_irods_resource_plugin_s3_fujifilm.py
@@ -59,4 +59,6 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_put_get_large_file_in_repl_node(self):
         pass
 
-
+    @unittest.skip('test does not work in decoupled because we are using same bucket for multiple resources')
+    def test_s3_in_replication_node__issues_2102_2122(self):
+        pass

--- a/packaging/test_irods_resource_plugin_s3_gcs.py
+++ b/packaging/test_irods_resource_plugin_s3_gcs.py
@@ -65,4 +65,6 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_put_get_large_file_in_repl_node(self):
         pass
 
-
+    @unittest.skip('test does not work in decoupled because we are using same bucket for multiple resources')
+    def test_s3_in_replication_node__issues_2102_2122(self):
+        pass

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -104,6 +104,10 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_put_get_large_file_in_repl_node(self):
         pass
 
+    @unittest.skip('test does not work in decoupled because we are using same bucket for multiple resources')
+    def test_s3_in_replication_node__issues_2102_2122(self):
+        pass
+
     # issue 2024
     @unittest.skip("File removal too slow with MinIO")
     def test_put_get_file_greater_than_8GiB_two_threads(self):


### PR DESCRIPTION
Update S3 repl test to use checksum.

Do not run S3 repl test when in detached mode as we are using the same bucket for all resources thus the object keys conflict.