### PR TITLE
Issues 2110 2112 main

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -32,6 +32,7 @@ def get_package_type():
     return pt
 
 def install_test_prerequisites():
+    irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', '--upgrade', 'pip>=20.3.4'], check_rc=True)
     irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', 'boto3', '--upgrade'], check_rc=True)
     irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', 'minio', '--upgrade'], check_rc=True)
     irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'python3', '-m', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -92,9 +92,9 @@ def download_and_start_minio_server():
             del os.environ[minio_region_name_key]
 
         procs.append(subprocess.Popen([path_to_minio, 'server',
-                                       '--address', f':{p["address"]}',
-                                       '--console-address', f':{p["console_address"]}',
-                                       '/data']))
+                                       '--address', ':' + p["address"],
+                                       '--console-address', ':' + p["console_address"],
+                                       '/data_%s' % p[minio_region_name_key]]))
 
     return procs
 

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -46,12 +46,12 @@ class Test_S3_NoCache_V4(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCas
     # issue 2024
     @unittest.skip("File removal too slow with MinIO")
     def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
+        Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
 
     # issue 2024
     @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
     def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
+        Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
 class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -62,16 +62,6 @@ class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3endPoint = 'localhost:9000'
         self.s3EnableMPU=0
         super(Test_S3_NoCache_MPU_Disabled, self).__init__(*args, **kwargs)
-
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
 class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -104,16 +94,6 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_s3_in_replication_node__issues_2102_2122(self):
         pass
 
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
-
 class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
     '''
     This also tests signature V4 with the x-amz-date header.
@@ -126,13 +106,3 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3endPoint='localhost:9001'
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
-
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)

--- a/s3/s3_operations.cpp
+++ b/s3/s3_operations.cpp
@@ -1919,7 +1919,7 @@ namespace irods_s3 {
             return PASS(ret);
         }
 
-        if (object->size() > 0 && object->size() != static_cast<std::size_t>(object_size)) {
+        if (object->size() > 0 && object->size() != static_cast<rodsLong_t>(object_size)) {
             return ERROR(SYS_COPY_LEN_ERR, fmt::format(
                         "[resource_name={}] Error for file: \"{}\" inp data size: {} does not match stat size: {}.",
                         resource_name, object->physical_path(), object->size(), object_size));


### PR DESCRIPTION
This is to address several issues:

- 2110 and 2112 are cherry-picked changes from 4-2-stable into main (with python2 replaced by python3).
- 2128 is needed for a recent change in iRODS core changing size_t to rodsLong_t in file_object::size.
- 2129 addresses something missed in the minio test suite when #2115 was implemented causing minio tests to fail.

I ran this through the testing environment and it passed.