### PR TITLE
[2129] Updated reference to large file tests in minio file (4-2-stable)

### DIFF
--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -50,12 +50,12 @@ class Test_S3_NoCache_V4(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCas
     # issue 2024
     @unittest.skip("File removal too slow with MinIO")
     def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
+        Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
 
     # issue 2024
     @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
     def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
+        Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
 class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -66,16 +66,6 @@ class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3endPoint = 'localhost:9000'
         self.s3EnableMPU=0
         super(Test_S3_NoCache_MPU_Disabled, self).__init__(*args, **kwargs)
-
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
 class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -108,16 +98,6 @@ class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
     def test_s3_in_replication_node__issues_2102_2122(self):
         pass
 
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
-
 class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
     '''
     This also tests signature V4 with the x-amz-date header.
@@ -130,13 +110,3 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3endPoint='localhost:9001'
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
-
-    # issue 2024
-    @unittest.skip("File removal too slow with MinIO")
-    def test_put_get_file_greater_than_8GiB_two_threads(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_8GiB_two_threads(self)
-
-    # issue 2024
-    @unittest.skipIf(psutil.disk_usage('/').free < 4 * (4*1024*1024*1024 + 2), "not enough free space for four 4 GiB files (upload, download, and two on-disk MinIO)")
-    def test_put_get_file_greater_than_4GiB_one_thread(self):
-        Test_S3_NoCache_Base.test_put_get_file_greater_than_4GiB_one_thread(self)


### PR DESCRIPTION
This address something that was missed when #2115 was implemented causing minio tests to fail.

Two tests were moved from Test_S3_NoCache_Base to Test_S3_NoCache_Large_File_Tests_Base in that issue.  For the class that derives from Test_S3_NoCache_Large_File_Tests_Base, references to these needed to change in test_irods_resource_plugin_s3_minio.py.  The others were deleted as these methods no longer exist in the base class for them.

