### PR TITLE
[2124] Set the proper open flags on read for checksum after put. (4-2-stable)

### DIFF
--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -12,6 +12,7 @@ import urllib3
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Glacier_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Glacier_Base
 
@@ -105,7 +106,7 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -1,5 +1,6 @@
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 
 import psutil
@@ -57,7 +58,7 @@ class Test_S3_NoCache_V4(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCas
     def test_put_get_file_greater_than_4GiB_one_thread(self):
         Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.proto = 'HTTP'

--- a/s3/s3_transport/include/s3_transport.hpp
+++ b/s3/s3_transport/include/s3_transport.hpp
@@ -910,6 +910,8 @@ namespace irods::experimental::io::s3_transport
                 named_shared_memory_object& shm_obj,
                 int64_t s3_object_size)
         {
+            rodsLog(config_.developer_messages_log_level, "%s:%d (%s) [[%lu]] downloading object to cache\n",
+                                __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
 
             // shmem is already locked here
 


### PR DESCRIPTION
Added test cases for large file checksum with MPU disabled. Placed test case in a newly created class so that it only runs for MPU disabled.