### PR TITLE
[2124] Be selective when setting open flags on PUT_OPR in s3_file_open_operation() (4-2-stable)

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2759,3 +2759,30 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             s3plugin_lib.remove_if_exists(file2)
             s3plugin_lib.remove_if_exists(file1_get)
             s3plugin_lib.remove_if_exists(file2_get)
+
+class Test_S3_NoCache_MPU_Disabled_Base(Test_S3_NoCache_Base):
+
+    def test_iput_large_file_with_checksum_issue_2124(self):
+
+        try:
+
+            file1 = "issue_2124_file"
+            file1_get = "issue_2124_file.get"
+
+            # use a file size that is large enough for parallel transfers
+            file1_size = 32*1024*1024 + 1
+
+            # create and put file
+            lib.make_arbitrary_file(file1, file1_size)
+
+            self.user0.assert_icommand("iput -K " + file1)  # iput
+            with open(file1, 'rb') as f:
+                checksum = base64.b64encode(hashlib.sha256(f.read()).digest()).decode()
+            self.user0.assert_icommand("ils -L", 'STDOUT_SINGLELINE', "sha2:" + checksum)  # check proper checksum
+
+        finally:
+
+            # cleanup
+            self.user0.assert_icommand("irm -f {file1}".format(**locals()), 'EMPTY')
+            s3plugin_lib.remove_if_exists(file1)
+            s3plugin_lib.remove_if_exists(file1_get)

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -12,6 +12,7 @@ import urllib3
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Glacier_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Glacier_Base
 
@@ -105,7 +106,7 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -1,5 +1,6 @@
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 
 import psutil
@@ -57,7 +58,7 @@ class Test_S3_NoCache_V4(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCas
     def test_put_get_file_greater_than_4GiB_one_thread(self):
         Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.proto = 'HTTP'

--- a/s3/s3_operations.cpp
+++ b/s3/s3_operations.cpp
@@ -751,10 +751,23 @@ namespace irods_s3 {
             rodsLog(developer_messages_log_level, "%s:%d (%s) [[%lu]] oprType set to %d\n",
                     __FILE__, __LINE__, __FUNCTION__, thread_id, oprType);
 
-            // fix open mode
             ios_base::openmode open_mode;
-            if (oprType == PUT_OPR) {
-                open_mode = translate_open_mode_posix_to_stream(O_CREAT | O_WRONLY | O_TRUNC, __FUNCTION__);
+
+            // Update open_mode when oprType=PUT_OPR.  There are three scenarios to consider: 
+            //
+            //   1.  The mode is set to O_WRONLY.  This would not stream because the O_CREAT or
+            //       O_TRUNC flag are not set.  Update the open flag to O_WRONLY | O_CREAT | O_TRUNC 
+            //       as we know a PUT_OPR is always a full file write or overwrite.
+            //
+            //   2.  The mode is set to O_RDWR.  This happens when there is a write
+            //       which will be followed up by a read for the checksum.  This would not
+            //       allow streaming because the file is opened in read and write mode. 
+            //       As before, update the open flag to O_WRONLY | O_CREAT | O_TRUNC.
+            //
+            //   2.  The mode is set to O_RDONLY.  This is the read for checksum that follows the
+            //       write.   Leave the oprType alone in this scenario. 
+            if (oprType == PUT_OPR && (file_obj->flags() & O_WRONLY || file_obj->flags() & O_RDWR)) {
+                open_mode = translate_open_mode_posix_to_stream(O_WRONLY | O_CREAT | O_TRUNC, __FUNCTION__);
             } else {
                 open_mode = translate_open_mode_posix_to_stream(file_obj->flags(), __FUNCTION__);
             }

--- a/s3/s3_transport/include/s3_transport.hpp
+++ b/s3/s3_transport/include/s3_transport.hpp
@@ -910,6 +910,8 @@ namespace irods::experimental::io::s3_transport
                 named_shared_memory_object& shm_obj,
                 int64_t s3_object_size)
         {
+            rodsLog(config_.developer_messages_log_level, "%s:%d (%s) [[%lu]] downloading object to cache\n",
+                                __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
 
             // shmem is already locked here
 


### PR DESCRIPTION
Added test cases for large file checksum with MPU disabled. Placed test case in a newly created class so that it only runs for MPU disabled.

Note that this replaces pull request #2132 as I went with a different/simpler approach.

All tests passed.