### PR TITLE
[2124] Be selective when setting open flags on PUT_OPR in s3_file_ope… (main)

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2807,3 +2807,30 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             s3plugin_lib.remove_if_exists(file2)
             s3plugin_lib.remove_if_exists(file1_get)
             s3plugin_lib.remove_if_exists(file2_get)
+
+class Test_S3_NoCache_MPU_Disabled_Base(Test_S3_NoCache_Base):
+
+    def test_iput_large_file_with_checksum_issue_2124(self):
+
+        try:
+
+            file1 = "issue_2124_file"
+            file1_get = "issue_2124_file.get"
+
+            # use a file size that is large enough for parallel transfers
+            file1_size = 32*1024*1024 + 1
+
+            # create and put file
+            lib.make_arbitrary_file(file1, file1_size)
+
+            self.user0.assert_icommand("iput -K " + file1)  # iput
+            with open(file1, 'rb') as f:
+                checksum = base64.b64encode(hashlib.sha256(f.read()).digest()).decode()
+            self.user0.assert_icommand("ils -L", 'STDOUT_SINGLELINE', "sha2:" + checksum)  # check proper checksum
+
+        finally:
+
+            # cleanup
+            self.user0.assert_icommand("irm -f {file1}".format(**locals()), 'EMPTY')
+            s3plugin_lib.remove_if_exists(file1)
+            s3plugin_lib.remove_if_exists(file1_get)

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -12,6 +12,7 @@ import urllib3
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Glacier_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Glacier_Base
 
@@ -105,7 +106,7 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -1,5 +1,6 @@
 from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 
 import psutil
@@ -53,7 +54,7 @@ class Test_S3_NoCache_V4(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCas
     def test_put_get_file_greater_than_4GiB_one_thread(self):
         Test_S3_NoCache_Large_File_Tests_Base.test_put_get_file_greater_than_4GiB_one_thread(self)
 
-class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_MPU_Disabled(Test_S3_NoCache_MPU_Disabled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.proto = 'HTTP'

--- a/s3/s3_transport/include/s3_transport.hpp
+++ b/s3/s3_transport/include/s3_transport.hpp
@@ -909,6 +909,8 @@ namespace irods::experimental::io::s3_transport
                 named_shared_memory_object& shm_obj,
                 std::int64_t s3_object_size)
         {
+            logger::debug("{}:{} ({}) [[{}]] downloading object to cache\n",
+                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
 
             // shmem is already locked here
 


### PR DESCRIPTION
This is a cherry-pick from the one for 4-2-stable.  The only difference is the format of the one added log message.

All tests passed.