### PR TITLE
[#2147] use static_cast when instantiating ios_base::openmode with an int

### DIFF
--- a/s3/s3_operations.cpp
+++ b/s3/s3_operations.cpp
@@ -431,7 +431,7 @@ namespace irods_s3 {
                 (oflag & O_ACCMODE) == O_WRONLY, (oflag & O_ACCMODE) == O_RDWR, (oflag & O_ACCMODE) == O_RDONLY,
                 (oflag & O_TRUNC) != 0, (oflag & O_CREAT) != 0, (oflag & O_APPEND) != 0);
 
-        ios_base::openmode mode = 0;
+        ios_base::openmode mode = static_cast<ios_base::openmode>(0);
 
         if ((oflag & O_ACCMODE) == O_WRONLY || (oflag & O_ACCMODE) == O_RDWR) {
             mode |= ios_base::out;

--- a/s3/s3_transport/include/s3_transport.hpp
+++ b/s3/s3_transport/include/s3_transport.hpp
@@ -228,7 +228,7 @@ namespace irods::experimental::io::s3_transport
             , call_s3_download_part_flag_{true}
             , begin_part_upload_thread_ptr_{nullptr}
             , circular_buffer_{_config.circular_buffer_size, _config.circular_buffer_timeout_seconds}
-            , mode_{0}
+            , mode_{static_cast<std::ios_base::openmode>(0)}
             , file_offset_{0}
             , existing_object_size_{config::UNKNOWN_OBJECT_SIZE}
             , download_to_cache_{true}


### PR DESCRIPTION
Addresses #2147

Still needs to be tested against libc++