### PR TITLE
Issue 2146 main

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -119,8 +119,6 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         if hasattr(self, 's3sse'):
             self.s3_context += ';S3_SERVER_ENCRYPT=' + str(self.s3sse)
 
-        self.s3_context += ';ARCHIVE_NAMING_POLICY=' + self.archive_naming_policy
-
         self.admin.assert_icommand("iadmin modresc demoResc name origResc", 'STDOUT_SINGLELINE', 'rename', input='yes\n')
 
         self.admin.assert_icommand("iadmin mkresc demoResc s3 " + hostname + ":/" + self.s3bucketname + "/demoResc " + self.s3_context, 'STDOUT_SINGLELINE', 's3')
@@ -2869,3 +2867,39 @@ class Test_S3_NoCache_MPU_Disabled_Base(Test_S3_NoCache_Base):
             self.user0.assert_icommand("irm -f {file1}".format(**locals()), 'EMPTY')
             s3plugin_lib.remove_if_exists(file1)
             s3plugin_lib.remove_if_exists(file1_get)
+
+class Test_S3_NoCache_Decoupled_Base(Test_S3_NoCache_Base):
+
+    def test_decoupled_redirect_issue_2146(self):
+
+        file1 = "f1"
+        file1_size = 2*1024*1024
+        retrieved_file = "f1.get"
+        resource_host = test.settings.HOSTNAME_3
+        resource_name = "s3_resc_on_host3"
+
+        # create an S3 resource
+        self.admin.assert_icommand(f'iadmin mkresc {resource_name} s3 {resource_host}:/{self.s3bucketname}/{resource_name} {self.s3_context}', 'STDOUT_SINGLELINE', 's3')
+
+        try:
+            # create the file
+            lib.make_arbitrary_file(file1, file1_size)
+
+            # put the file
+            self.user1.assert_icommand(f'iput -R {resource_name} {file1}')  # iput
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget {file1} {retrieved_file}')
+
+            self.assertTrue(filecmp.cmp(file1, retrieved_file))  # confirm retrieved is correct
+
+            # verify in the physical path that decoupled mode was used
+            print(self.user1.run_icommand(['ils', '-l', file1])[0])   # just debug
+            self.user1.assert_icommand(f'ils -L {file1}', 'STDOUT_SINGLELINE', f'/{self.s3bucketname}/[0-9]+/{file1}', use_regex=True)
+
+        finally:
+            # cleanup
+            self.user1.assert_icommand("irm -f %s" % file1)  # irm
+            self.admin.assert_icommand("iadmin rmresc %s" % resource_name)
+            s3plugin_lib.remove_if_exists(file1)
+            s3plugin_lib.remove_if_exists(retrieved_file)

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2903,3 +2903,121 @@ class Test_S3_NoCache_Decoupled_Base(Test_S3_NoCache_Base):
             self.admin.assert_icommand("iadmin rmresc %s" % resource_name)
             s3plugin_lib.remove_if_exists(file1)
             s3plugin_lib.remove_if_exists(retrieved_file)
+
+    # This verifies that once the file is written to the DB, whatever mode was used remains in effect as the DB always wins.
+    def test_resource_updated_from_consistent_to_decoupled_issue_2161(self):
+
+        file1 = "f1"
+        file1_size = 2*1024
+        file2 = "f2"
+        file2_size = 3*1024
+        retrieved_file = 'f.get'
+        hostname = lib.get_hostname()
+        resource_name = "s3_resc"
+
+        s3_context_consistent = self.s3_context.replace('ARCHIVE_NAMING_POLICY=decoupled', 'ARCHIVE_NAMING_POLICY=consistent')
+        s3_context_decoupled = self.s3_context
+
+        # create the S3 resource
+        self.admin.assert_icommand(f'iadmin mkresc {resource_name} s3 {hostname}:/{self.s3bucketname}/{resource_name} {s3_context_consistent}', 'STDOUT_SINGLELINE', 's3')
+
+        try:
+            # create file1 and file2
+            lib.make_arbitrary_file(file1, file1_size)
+            lib.make_arbitrary_file(file2, file2_size)
+
+            # put file1
+            self.user1.assert_icommand(f'iput -R {resource_name} {file1}')
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file1, retrieved_file))  # confirm retrieved is correct
+
+            # verify in the physical path that consistent mode was used
+            print(self.user1.run_icommand(['ils', '-l', file1])[0])   # just debug
+            self.user1.assert_icommand(f'ils -L {file1}', 'STDOUT_SINGLELINE', f'/{self.s3bucketname}/{resource_name}/home/.+/{file1}', use_regex=True)
+
+            # update the resource to decoupled mode
+            self.admin.run_icommand(f'iadmin modresc {resource_name} context {s3_context_decoupled}')
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget -f {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file1, retrieved_file))  # confirm retrieved is correct with file1
+
+            # overwrite file1 with file2
+            self.user1.assert_icommand(f'iput -f -R {resource_name} {file2} {file1}')
+
+            # verify the path remains in consistent mode (DB rules)
+            print(self.user1.run_icommand(['ils', '-l', file1])[0])   # just debug
+            self.user1.assert_icommand(f'ils -L {file1}', 'STDOUT_SINGLELINE', f'/{self.s3bucketname}/{resource_name}/home/.+/{file1}', use_regex=True)
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget -f {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file2, retrieved_file))  # confirm retrieved is correct with file2
+
+        finally:
+            # cleanup
+            self.user1.assert_icommand("irm -f %s" % file1)  # irm
+            self.admin.assert_icommand("iadmin rmresc %s" % resource_name)
+            s3plugin_lib.remove_if_exists(file1)
+            s3plugin_lib.remove_if_exists(file2)
+            s3plugin_lib.remove_if_exists(retrieved_file)
+
+    # This verifies that once the file is written to the DB, whatever mode was used remains in effect as the DB always wins.
+    def test_resource_updated_from_decoupled_to_consistent_issue_2161(self):
+
+        file1 = "f1"
+        file1_size = 2*1024
+        file2 = "f2"
+        file2_size = 3*1024
+        retrieved_file = 'f.get'
+        hostname = lib.get_hostname()
+        resource_name = "s3_resc"
+
+        s3_context_consistent = self.s3_context.replace('ARCHIVE_NAMING_POLICY=decoupled', 'ARCHIVE_NAMING_POLICY=consistent')
+        s3_context_decoupled = self.s3_context
+
+        # create the S3 resource
+        self.admin.assert_icommand(f'iadmin mkresc {resource_name} s3 {hostname}:/{self.s3bucketname}/{resource_name} {s3_context_decoupled}', 'STDOUT_SINGLELINE', 's3')
+
+        try:
+            # create file1 and file2
+            lib.make_arbitrary_file(file1, file1_size)
+            lib.make_arbitrary_file(file2, file2_size)
+
+            # put file1
+            self.user1.assert_icommand(f'iput -R {resource_name} {file1}')
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file1, retrieved_file))  # confirm retrieved is correct
+
+            # verify in the physical path that decoupled mode was used
+            print(self.user1.run_icommand(['ils', '-l', file1])[0])   # just debug
+            self.user1.assert_icommand(f'ils -L {file1}', 'STDOUT_SINGLELINE', f'/{self.s3bucketname}/[0-9]+/{file1}', use_regex=True)
+
+            # update the resource to consistent mode
+            self.admin.run_icommand(f'iadmin modresc {resource_name} context {s3_context_consistent}')
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget -f {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file1, retrieved_file))  # confirm retrieved is correct with file1
+
+            # overwrite file1 with file2
+            self.user1.assert_icommand(f'iput -f -R {resource_name} {file2} {file1}')
+
+            # verify the path remains in decoupled mode (DB rules)
+            print(self.user1.run_icommand(['ils', '-l', file1])[0])   # just debug
+            self.user1.assert_icommand(f'ils -L {file1}', 'STDOUT_SINGLELINE', f'/{self.s3bucketname}/[0-9]+/{file1}', use_regex=True)
+
+            # get and verify the file contents
+            self.user1.assert_icommand(f'iget -f {file1} {retrieved_file}')
+            self.assertTrue(filecmp.cmp(file2, retrieved_file))  # confirm retrieved is correct with file2
+
+        finally:
+            # cleanup
+            self.user1.assert_icommand("irm -f %s" % file1)  # irm
+            self.admin.assert_icommand("iadmin rmresc %s" % resource_name)
+            s3plugin_lib.remove_if_exists(file1)
+            s3plugin_lib.remove_if_exists(file2)
+            s3plugin_lib.remove_if_exists(retrieved_file)

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -13,6 +13,7 @@ from .resource_suite_s3_nocache import Test_S3_NoCache_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Large_File_Tests_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_Glacier_Base
 from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
+from .resource_suite_s3_nocache import Test_S3_NoCache_Decoupled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Glacier_Base
 
@@ -125,7 +126,7 @@ class Test_S3_NoCache_SSE(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3EnableMPU=1
         super(Test_S3_NoCache_SSE, self).__init__(*args, **kwargs)
 
-class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Base, unittest.TestCase):
+class Test_S3_NoCache_Decoupled(Test_S3_NoCache_Decoupled_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
         self.keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'


### PR DESCRIPTION
This fixes issue #2146. All tests passed.

 In addition, I added two general test cases to test switching archive naming policy consistent->decoupled and decoupled->consistent after object had already been created. These were added for the following reasons:

1. This is something we should be testing since the physical path in the DB for existing objects should override the archive naming policy.
2. On my first attempt to fix 2146 I broke this behavior and realized there was no specific test for this.

See 03eb431b059802458a2d2ffde02ecdc636295e50 which fixes the scenario I was trying to fix with the open flags.  I am now checking the openType.  This is now working as expected.