### PR TITLE
[2146] Fixed a physical_path() that should have been a logical_path()

### DIFF
--- a/s3/s3_operations.cpp
+++ b/s3/s3_operations.cpp
@@ -441,7 +441,7 @@ namespace irods_s3 {
                 // There is no L1desc[] entry. Look up the object_id via GenQuery. Reverse it
                 // for the key.  Write the physical_path to object->physical_path().
 
-                auto path(boost::filesystem::path(object->physical_path()));
+                auto path(boost::filesystem::path(object->logical_path()));
                 std::string query_string = fmt::format("SELECT DATA_ID WHERE DATA_NAME = '{}' AND COLL_NAME = '{}'",
                                                        path.filename().c_str(),
                                                        path.parent_path().c_str());


### PR DESCRIPTION
This is a fix for the previous pull request.  Somehow in the process of cherry-picking from main and making necessary manual updates, I changed logical_path() to physical_path().  It was missed in testing (which must be done manually) because I accidentally had the resource set to detached mode.

This has passed all testing.