### PR TITLE
[#2138] Remove libs3 from build hook (4-3-stable)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -46,7 +46,6 @@ def install_building_dependencies(externals_directory):
         'irods-externals-fmt8.1.1-0',
         'irods-externals-json3.10.4-0',
         'irods-externals-libarchive3.5.2-0',
-        'irods-externals-libs3e8457e09-0',
         'irods-externals-nanodbc2.13.0-1',
         'irods-externals-spdlog1.9.2-1',
         'irods-externals-zeromq4-14.1.8-0'


### PR DESCRIPTION
Missed this in #2152

In service of #2138