### PR TITLE
[2198] Do not blindly set #threads to requested #threads (4-3-stable)

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -2488,6 +2488,120 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
             s3plugin_lib.remove_if_exists(get_filename2)
             s3plugin_lib.remove_if_exists(get_filename3)
 
+    def test_multiple_irsync_to_s3__issue_2204(self):
+
+        filename1 = f'{inspect.currentframe().f_code.co_name}1'
+        get_filename1 = f'{filename1}.get'
+        filename2 = f'{inspect.currentframe().f_code.co_name}2'
+        get_filename2 = f'{filename2}.get'
+
+        try:
+            # create 
+            lib.make_arbitrary_file(f'{filename1}', 100*1024*1024)
+
+            # put filename1 
+            self.user1.assert_icommand(f'iput -K {filename1}')
+
+            # irsync to filename2
+            self.user1.assert_icommand(f'irsync -K i:{filename1} i:{filename2}')
+
+            # verify the files are in iRODS 
+            self.user1.assert_icommand(f'ils -l', 'STDOUT_MULTILINE', [filename1, filename2])
+
+            # get filename1 and filename2
+            self.user1.assert_icommand(f'iget {filename1} {get_filename1}')
+            self.user1.assert_icommand(f'iget {filename2} {get_filename2}')
+            
+            # verify the files are the same
+            assert_command(['diff', '-q', filename1, get_filename1])
+            assert_command(['diff', '-q', filename1, get_filename2])
+
+            # remove filename2 and the downloaded files
+            self.user1.assert_icommand(f'irm -f {filename2}')
+            s3plugin_lib.remove_if_exists(get_filename1)
+            s3plugin_lib.remove_if_exists(get_filename2)
+
+            # perform a second irsync to test that shmem is clean
+
+            # irsync to filename2
+            self.user1.assert_icommand(f'irsync -K i:{filename1} i:{filename2}')
+
+            # verify the files are in iRODS 
+            self.user1.assert_icommand(f'ils -l', 'STDOUT_MULTILINE', [filename1, filename2])
+
+            # get filename1 and filename2
+            self.user1.assert_icommand(f'iget {filename1} {get_filename1}')
+            self.user1.assert_icommand(f'iget {filename2} {get_filename2}')
+            
+            # verify the files are the same
+            assert_command(['diff', '-q', filename1, get_filename1])
+            assert_command(['diff', '-q', filename1, get_filename2])
+
+        finally:
+            # clean up the file that was put in case it wasn't cleaned up
+            self.user1.assert_icommand(f'irm -rf {filename1}')
+            self.user1.assert_icommand(f'irm -rf {filename2}')
+            s3plugin_lib.remove_if_exists(filename1)
+            s3plugin_lib.remove_if_exists(get_filename1)
+            s3plugin_lib.remove_if_exists(get_filename2)
+
+    def test_multiple_irsync_to_s3_with_N_flag__issue_2204(self):
+
+        filename1 = f'{inspect.currentframe().f_code.co_name}1'
+        get_filename1 = f'{filename1}.get'
+        filename2 = f'{inspect.currentframe().f_code.co_name}2'
+        get_filename2 = f'{filename2}.get'
+
+        try:
+            # create 
+            lib.make_arbitrary_file(f'{filename1}', 100*1024*1024)
+
+            # put filename1 
+            self.user1.assert_icommand(f'iput -K {filename1}')
+
+            # irsync to filename2
+            self.user1.assert_icommand(f'irsync -N3 -K i:{filename1} i:{filename2}')
+
+            # verify the files are in iRODS 
+            self.user1.assert_icommand(f'ils -l', 'STDOUT_MULTILINE', [filename1, filename2])
+
+            # get filename1 and filename2
+            self.user1.assert_icommand(f'iget {filename1} {get_filename1}')
+            self.user1.assert_icommand(f'iget {filename2} {get_filename2}')
+            
+            # verify the files are the same
+            assert_command(['diff', '-q', filename1, get_filename1])
+            assert_command(['diff', '-q', filename1, get_filename2])
+
+            # remove filename2 and the downloaded files
+            self.user1.assert_icommand(f'irm -f {filename2}')
+            s3plugin_lib.remove_if_exists(get_filename1)
+            s3plugin_lib.remove_if_exists(get_filename2)
+
+            # perform a second irsync to test that shmem is clean
+
+            # irsync to filename2
+            self.user1.assert_icommand(f'irsync -N3 -K i:{filename1} i:{filename2}')
+
+            # verify the files are in iRODS 
+            self.user1.assert_icommand(f'ils -l', 'STDOUT_MULTILINE', [filename1, filename2])
+
+            # get filename1 and filename2
+            self.user1.assert_icommand(f'iget {filename1} {get_filename1}')
+            self.user1.assert_icommand(f'iget {filename2} {get_filename2}')
+            
+            # verify the files are the same
+            assert_command(['diff', '-q', filename1, get_filename1])
+            assert_command(['diff', '-q', filename1, get_filename2])
+
+        finally:
+            # clean up the file that was put in case it wasn't cleaned up
+            self.user1.assert_icommand(f'irm -rf {filename1}')
+            self.user1.assert_icommand(f'irm -rf {filename2}')
+            s3plugin_lib.remove_if_exists(filename1)
+            s3plugin_lib.remove_if_exists(get_filename1)
+            s3plugin_lib.remove_if_exists(get_filename2)
+
 class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass'), ('bobby', 'bpass')])):
 
     def __init__(self, *args, **kwargs):

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -15,6 +15,9 @@ import io
 import psutil
 import subprocess
 import distro
+import inspect
+import shutil
+from ..test.command import assert_command
 
 from .. import paths
 from ..configuration import IrodsConfig
@@ -2405,6 +2408,85 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
             self.admin.assert_icommand("iadmin rmresc %s" % resource_name)
             s3plugin_lib.remove_if_exists(file1)
             s3plugin_lib.remove_if_exists(retrieved_file)
+
+    def test_iput_with_N_flag__issue_2198(self):
+
+        filename = f'{inspect.currentframe().f_code.co_name}'
+        get_filename = f'{filename}.get'
+        try:
+            file_sizes = [
+                    100,
+                    32 * 1024 * 1024 - 1,
+                    32 * 1024 * 1024,
+                    32 * 1024 * 1024 + 1,
+                    100 * 1024 * 1024
+                    ];
+
+            for file_size in file_sizes:
+                # create the file
+                lib.make_arbitrary_file(filename, file_size)
+
+                # put the file
+                self.user1.assert_icommand(f'iput {filename}')
+                self.user1.assert_icommand(f'iget -f {filename} {get_filename}')
+                assert_command(['diff', '-q', filename, get_filename])
+
+                for n_value in [0, 1, 2, 3, 4, 8]:
+                    self.user1.assert_icommand(f'iput -f -N{n_value} {filename}')
+                    self.user1.assert_icommand(f'iget -f {filename} {get_filename}')
+                    assert_command(['diff', '-q', filename, get_filename])
+
+                # cleanup before next loop
+                s3plugin_lib.remove_if_exists(filename)
+                s3plugin_lib.remove_if_exists(get_filename)
+                self.user1.assert_icommand(f'irm -f {filename}')
+
+        finally:
+            # clean up anything that wasn't cleaned up earlier
+            s3plugin_lib.remove_if_exists(filename)
+            s3plugin_lib.remove_if_exists(get_filename)
+            self.user1.assert_icommand(f'irm -f {filename}')
+
+    def test_recursive_put_small_files_with_checksum_and_N_flag__issue_2198(self):
+
+        dirname = f'{inspect.currentframe().f_code.co_name}'
+        filename1 = f'{inspect.currentframe().f_code.co_name}1'
+        get_filename1 = f'{filename1}.get'
+        filename2 = f'{inspect.currentframe().f_code.co_name}2'
+        get_filename2 = f'{filename2}.get'
+        filename3 = f'{inspect.currentframe().f_code.co_name}3'
+        get_filename3 = f'{filename3}.get'
+
+        try:
+            # create the local directory
+            os.mkdir(dirname)
+
+            # create the files
+            lib.make_arbitrary_file(f'{dirname}/{filename1}', 100)
+            lib.make_arbitrary_file(f'{dirname}/{filename2}', 100)
+            lib.make_arbitrary_file(f'{dirname}/{filename3}', 100)
+
+            # recursively put the directory
+            self.user1.assert_icommand(f'iput -r -N2 -K {dirname}')
+
+            #verify the files are in iRODS 
+            self.user1.assert_icommand(f'ils -l {dirname}', 'STDOUT_MULTILINE', [filename1, filename2, filename3])
+
+            # get and verify the file contents 
+            self.user1.assert_icommand(f'iget {dirname}/{filename1} {get_filename1}')
+            self.user1.assert_icommand(f'iget {dirname}/{filename2} {get_filename2}')
+            self.user1.assert_icommand(f'iget {dirname}/{filename3} {get_filename3}')
+            assert_command(['diff', '-q', f'{dirname}/{filename1}', get_filename1])
+            assert_command(['diff', '-q', f'{dirname}/{filename2}', get_filename2])
+            assert_command(['diff', '-q', f'{dirname}/{filename3}', get_filename3])
+
+        finally:
+            # clean up whatever was not cleaned up
+            self.user1.assert_icommand(f'irm -rf {dirname}')
+            shutil.rmtree(dirname)
+            s3plugin_lib.remove_if_exists(get_filename1)
+            s3plugin_lib.remove_if_exists(get_filename2)
+            s3plugin_lib.remove_if_exists(get_filename3)
 
 class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'rods')], [('alice', 'apass'), ('bobby', 'bpass')])):
 

--- a/s3_resource/src/s3_operations.cpp
+++ b/s3_resource/src/s3_operations.cpp
@@ -327,24 +327,22 @@ namespace irods_s3 {
                     }
             }
 
-            // if number of threads was not successfully set above
-            if (number_of_threads == 0) {
+			// If number of threads was not successfully set above.
+			if (number_of_threads == 0) {
+				const int single_buff_sz = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
 
-                const int single_buff_sz = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
+				if (data_size > single_buff_sz && oprType != REPLICATE_DEST) {
+					number_of_threads = getNumThreads(_ctx.comm(),
+					                                  data_size,
+					                                  requested_number_of_threads,
+					                                  const_cast<KeyValPair*>(&file_obj->cond_input()),
+					                                  nullptr, // destination resc hier
+					                                  nullptr, // source resc hier
+					                                  0);      // opr type - not used
+				}
+			}
 
-                if (data_size > single_buff_sz && oprType != REPLICATE_DEST && oprType != COPY_DEST) {
-
-                    number_of_threads = getNumThreads( _ctx.comm(),
-                            data_size,
-                            requested_number_of_threads,
-                            const_cast<KeyValPair*>(&file_obj->cond_input()),
-                            nullptr,                     // destination resc hier
-                            nullptr,                     // source resc hier
-                            0 );                         // opr type - not used
-                }
-            }
-
-            // If we still don't know the # of threads, set it to 1 unless the oprType is unknown in
+			// If we still don't know the # of threads, set it to 1 unless the oprType is unknown in
             // which case it will remain <= 0 which will force use of cache.
             if (number_of_threads <= 0 && oprType != -1) {
                 number_of_threads = 1;

--- a/s3_resource/src/s3_operations.cpp
+++ b/s3_resource/src/s3_operations.cpp
@@ -331,7 +331,6 @@ namespace irods_s3 {
             if (number_of_threads == 0) {
 
                 const int single_buff_sz = irods::get_advanced_setting<const int>(irods::KW_CFG_MAX_SIZE_FOR_SINGLE_BUFFER) * 1024 * 1024;
-                number_of_threads = requested_number_of_threads;
 
                 if (data_size > single_buff_sz && oprType != REPLICATE_DEST && oprType != COPY_DEST) {
 


### PR DESCRIPTION
This is the same as pull request #2199 but with Python3 changes as well as a slight change in output when iput -r is run in 4.3.