### PR TITLE
Issue 2205 - 4-3-stable

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -1190,9 +1190,9 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
 
     def test_iput_large_file_over_smaller(self):
 
-        file1 = "f1"
-        file2 = "f2"
-        filename_get = "f3"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+        file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+        filename_get = f'{inspect.currentframe().f_code.co_name}_get'
 
         file1_size = pow(2,20)
         file2_size = 512*pow(2,20)
@@ -1227,9 +1227,9 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
 
     def test_iput_small_file_over_larger(self):
 
-        file1 = "f1"
-        file2 = "f2"
-        filename_get = "f3"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+        file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+        filename_get = f'{inspect.currentframe().f_code.co_name}_get'
 
         file1_size = 512*pow(2,20)
         file2_size = pow(2,20)
@@ -1453,7 +1453,7 @@ INPUT null
 OUTPUT ruleExecOut
         '''.format(**locals())
 
-        file1 = 'f1'
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         write_rule_file_path = 'test_small_write.r'
         read_rule_file_path = 'test_small_read.r'
 
@@ -1493,8 +1493,8 @@ OUTPUT ruleExecOut
     def test_detached_mode(self):
 
         try:
-            file1 = "f1"
-            file2 = "f2"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
             resource_host = "irods.org"
             resource_name = 's3resc1'
 
@@ -1547,7 +1547,7 @@ OUTPUT ruleExecOut
         # in non-topology HOSTNAME_3 is just local host so it really doesn't test detached mode
         # but in topology it will
 
-        file1 = "f1"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         #resource_host = test.settings.HOSTNAME_3
         resource_host = "irods.org"
 
@@ -1608,8 +1608,8 @@ OUTPUT ruleExecOut
 
         try:
 
-            file1 = "f1"
-            file2 = "f2"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
             lib.make_file(file1, 128*1024*1024, 'arbitrary')
             self.user0.assert_icommand("iput {file1}".format(**locals()))  # iput
             self.user0.assert_icommand("imv {file1} {file2}".format(**locals()))  # imv
@@ -1640,9 +1640,9 @@ OUTPUT ruleExecOut
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc3", 'EMPTY')
 
             # create and put file
-            file1 = "f1"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
             lib.make_file(file1, 1024, 'arbitrary')
-            file2 = "f1.get"
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
             self.user0.assert_icommand("iput -R s3repl {file1}".format(**locals()))  # iput
 
             # get file from first repl
@@ -1698,8 +1698,8 @@ OUTPUT ruleExecOut
             self.admin.assert_icommand("iadmin addchildtoresc s3repl s3resc3", 'EMPTY')
 
             # create and put file
-            file1 = "f1"
-            file2 = "f1.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
             lib.make_file(file1, 120*1024*1024)
             self.user0.assert_icommand("iput -R s3repl {file1}".format(**locals()))  # iput
 
@@ -1776,8 +1776,8 @@ OUTPUT ruleExecOut
                     320 * 1024 * 1024 + 1, # 16 threads, different sizes, multipart upload, three parts per thread
                     ];
 
-            file1 = "f1"
-            file2 = "f1.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
 
             for file_size in file_sizes:
 
@@ -1814,7 +1814,7 @@ OUTPUT ruleExecOut
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
             file_size = 120*1024*1024;
 
             # create and put file
@@ -2235,8 +2235,8 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file2 = "f1.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
 
             file_size = 4*1024*1024*1024 + 1  # +1 - make sure one thread handles more than 4 GiB
 
@@ -2276,8 +2276,8 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, self.s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file2 = "f1.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
 
             file_size = 8*1024*1024*1024 + 2  # +2 - make sure each thread handles more than 4 GiB
 
@@ -2333,8 +2333,8 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
             self.admin.assert_icommand("iadmin addchildtoresc replresc s3resc1", 'EMPTY')
             self.admin.assert_icommand("iadmin addchildtoresc replresc s3resc2", 'EMPTY')
 
-            file1 = "f1"
-            file2 = "f1.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
 
             file_size = 1024*1024*1024;
 
@@ -2377,8 +2377,8 @@ class Test_S3_NoCache_Large_File_Tests_Base(Test_S3_NoCache_Base):
         # in non-topology HOSTNAME_3 is just local host so it really doesn't test detached mode
         # but in topology it will
 
-        file1 = "f1"
-        retrieved_file = "f1.get"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+        retrieved_file = f'{inspect.currentframe().f_code.co_name}_get'
         resource_host = test.settings.HOSTNAME_3
         resource_name = "s3_resc_on_host3"
 
@@ -2747,10 +2747,10 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
             file1_get = "f1.get"
-            file2 = "f2"
-            file2_get = "f2.get"
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+            file2_get = f'{file2}_get'
 
             file1_size = 8*1024*1024
             file2_size = 32*1024*1024 + 1
@@ -2818,10 +2818,10 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file1_get = "f1.get"
-            file2 = "f2"
-            file2_get = "f2.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file1_get = f'{file1}_get'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+            file2_get = f'{file2}_get'
 
             file1_size = 8*1024*1024
             file2_size = 32*1024*1024 + 1
@@ -2879,10 +2879,10 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file1_get = "f1.get"
-            file2 = "f2"
-            file2_get = "f2.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file1_get = f'{file1}_get'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+            file2_get = f'{file2}_get'
 
             file1_size = 8*1024*1024
             file2_size = 32*1024*1024 + 1
@@ -2941,10 +2941,10 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file1_get = "f1.get"
-            file2 = "f2"
-            file2_get = "f2.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file1_get = f'{file1}_get'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+            file2_get = f'{file2}_get'
 
             file1_size = 8*1024*1024
             file2_size = 32*1024*1024 + 1
@@ -3003,10 +3003,10 @@ class Test_S3_NoCache_Glacier_Base(session.make_sessions_mixin([('otherrods', 'r
             self.admin.assert_icommand("iadmin mkresc s3resc1 s3 %s:/%s/%s/s3resc1 %s" %
                                    (hostname, self.s3bucketname, hostuser, s3_context), 'STDOUT_SINGLELINE', "Creating")
 
-            file1 = "f1"
-            file1_get = "f1.get"
-            file2 = "f2"
-            file2_get = "f2.get"
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+            file1_get = f'{file1}_get'
+            file2 = f'{inspect.currentframe().f_code.co_name}_f2'
+            file1_get = f'{file2}_get'
 
             file1_size = 8*1024*1024
             file2_size = 32*1024*1024 + 1
@@ -3070,9 +3070,9 @@ class Test_S3_NoCache_Decoupled_Base(Test_S3_NoCache_Base):
 
     def test_decoupled_redirect_issue_2146(self):
 
-        file1 = "f1"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024*1024
-        retrieved_file = "f1.get"
+        retrieved_file = f'{inspect.currentframe().f_code.co_name}_get'
         resource_host = test.settings.HOSTNAME_3
         resource_name = "s3_resc_on_host3"
 
@@ -3105,11 +3105,11 @@ class Test_S3_NoCache_Decoupled_Base(Test_S3_NoCache_Base):
     # This verifies that once the file is written to the DB, whatever mode was used remains in effect as the DB always wins.
     def test_resource_updated_from_consistent_to_decoupled_issue_2161(self):
 
-        file1 = "f1"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024
-        file2 = "f2"
+        file2 = f'{inspect.currentframe().f_code.co_name}_f2'
         file2_size = 3*1024
-        retrieved_file = 'f.get'
+        retrieved_file = f'{inspect.currentframe().f_code.co_name}_get'
         hostname = lib.get_hostname()
         resource_name = "s3_resc"
 
@@ -3164,11 +3164,11 @@ class Test_S3_NoCache_Decoupled_Base(Test_S3_NoCache_Base):
     # This verifies that once the file is written to the DB, whatever mode was used remains in effect as the DB always wins.
     def test_resource_updated_from_decoupled_to_consistent_issue_2161(self):
 
-        file1 = "f1"
+        file1 = f'{inspect.currentframe().f_code.co_name}_f1'
         file1_size = 2*1024
-        file2 = "f2"
+        file2 = f'{inspect.currentframe().f_code.co_name}_f2'
         file2_size = 3*1024
-        retrieved_file = 'f.get'
+        retrieved_file = f'{inspect.currentframe().f_code.co_name}_get'
         hostname = lib.get_hostname()
         resource_name = "s3_resc"
 

--- a/s3_resource/include/irods/private/s3_resource/multipart_shared_data.hpp
+++ b/s3_resource/include/irods/private/s3_resource/multipart_shared_data.hpp
@@ -1,0 +1,45 @@
+#ifndef IRODS_S3_RESOURCE_MULTIPART_SHARED_DATA_HPP
+#define IRODS_S3_RESOURCE_MULTIPART_SHARED_DATA_HPP
+
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/containers/map.hpp>
+#include <boost/interprocess/containers/vector.hpp>
+#include <boost/interprocess/containers/list.hpp>
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/containers/string.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/container/scoped_allocator.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+#include <iostream>
+
+namespace irods_s3 
+{
+    namespace interprocess_types
+    {
+        namespace bi          = boost::interprocess;
+        using segment_manager = bi::managed_shared_memory::segment_manager;
+        using void_allocator  = boost::container::scoped_allocator_adaptor<bi::allocator<void, segment_manager> >;
+    }
+
+    // data that needs to be shared among different processes
+    struct multipart_shared_data
+    {
+        explicit multipart_shared_data(const interprocess_types::void_allocator &allocator)
+            : threads_remaining_to_close{0}
+            , number_of_threads{0}
+            , ref_count{0}
+        {}
+
+        bool can_delete() {
+            return threads_remaining_to_close == 0;
+        }
+
+        int threads_remaining_to_close;
+        int number_of_threads;
+        int ref_count;
+    }; // struct multipart_shared_data
+} // namespace irods_s3
+
+#endif // IRODS_S3_RESOURCE_MULTIPART_SHARED_DATA_HPP

--- a/s3_transport/include/irods/private/s3_transport/managed_shared_memory_object.hpp
+++ b/s3_transport/include/irods/private/s3_transport/managed_shared_memory_object.hpp
@@ -40,7 +40,7 @@ namespace irods::experimental::interprocess
                     , last_access_time_in_seconds(access_time)
                 {}
 
-                // T must have reset_fields() and ref_count and can_delete()
+                // T must have ref_count and can_delete()
                 T thing;
 
                 time_t last_access_time_in_seconds;
@@ -83,7 +83,7 @@ namespace irods::experimental::interprocess
 
                 if (shmem_has_expired) {
 
-                    logger::debug("{}:{} ({}) SHMEM_HAS_EXPIRED", __FILE__, __LINE__, __FUNCTION__);
+                    logger::debug("{}:{} ({}) SHMEM_HAS_EXPIRED", __FILE__, __LINE__, __func__);
 
                     // rebuild shmem object
                     shm_.destroy<ipc_object>(SHARED_DATA_NAME.c_str());
@@ -110,9 +110,12 @@ namespace irods::experimental::interprocess
 
                         object_->thing.~T();
                         object_ = nullptr;
-                        bi::shared_memory_object::remove(shm_name_.c_str());
-                        bi::named_mutex::remove(shm_name_.c_str());
-
+                        if (!bi::shared_memory_object::remove(shm_name_.c_str())) {
+                            logger::error("{}:{} ({}) removal of shared memory object [{}] failed", __FILE__, __LINE__, __func__, shm_name_);
+                        }
+                        if (!bi::named_mutex::remove(shm_name_.c_str())) {
+                            logger::error("{}:{} ({}) removal of mutex for shared memory object [{}] failed", __FILE__, __LINE__, __func__, shm_name_);
+                        }
                     }
                 }
             }

--- a/s3_transport/include/irods/private/s3_transport/multipart_shared_data.hpp
+++ b/s3_transport/include/irods/private/s3_transport/multipart_shared_data.hpp
@@ -1,5 +1,5 @@
-#ifndef S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP
-#define S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP
+#ifndef IRODS_S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP
+#define IRODS_S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP
 
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/map.hpp>
@@ -55,21 +55,6 @@ namespace irods::experimental::io::s3_transport::shared_data
             , know_number_of_threads{true}
         {}
 
-        void reset_fields()
-        {
-            threads_remaining_to_close = 0;
-            done_initiate_multipart = false;
-            upload_id = "";
-            etags.clear();
-            last_error_code = error_codes::SUCCESS;
-            cache_file_download_progress = cache_file_download_status::NOT_STARTED;
-            ref_count = 1;   // current object has reference so ref_count = 1
-            circular_buffer_read_timeout = false;
-            file_open_counter = 0;
-            cache_file_flushed = false;
-            know_number_of_threads = true;
-        }
-
         bool can_delete() {
             return know_number_of_threads
                    ? threads_remaining_to_close == 0
@@ -94,4 +79,4 @@ namespace irods::experimental::io::s3_transport::shared_data
 
 
 
-#endif // S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP
+#endif // IRODS_S3_TRANSPORT_MULTIPART_SHARED_DATA_HPP

--- a/s3_transport/include/irods/private/s3_transport/util.hpp
+++ b/s3_transport/include/irods/private/s3_transport/util.hpp
@@ -52,12 +52,18 @@ namespace irods::experimental::io::s3_transport
         static const std::int64_t            BYTES_PER_ETAG{112};  // 80 bytes for every string added, 32 bytes for the vector size,
                                                               // determined by testing
         static const std::int64_t            UPLOAD_ID_SIZE{128};
-        static const std::int64_t            MAX_S3_SHMEM_SIZE{sizeof(shared_data::multipart_shared_data) +
+
+        // See https://groups.google.com/g/boost-list/c/5ADnEPYg-ho for an explanation
+        // of why the 100*sizeof(void*) is used below.  Essentially, the shared memory
+        // must have enough space for the memory algorithm and reserved area but there is
+        // no way of knowing the size for these.  It is stated that 100*sizeof(void*) would
+        // be enough.
+        static constexpr std::int64_t        MAX_S3_SHMEM_SIZE{100*sizeof(void*) + sizeof(shared_data::multipart_shared_data) +
                                                           MAXIMUM_NUMBER_ETAGS_PER_UPLOAD * (BYTES_PER_ETAG + 1) +
                                                           UPLOAD_ID_SIZE + 1};
 
         static const int                DEFAULT_SHARED_MEMORY_TIMEOUT_IN_SECONDS{900};
-        inline static const std::string SHARED_MEMORY_KEY_PREFIX{"irods_s3-shm-"};
+        inline static const std::string SHARED_MEMORY_KEY_PREFIX{"irods_s3_transport-shm-"};
     };
 
     void print_bucket_context( const libs3_types::bucket_context& bucket_context );


### PR DESCRIPTION
This pull request addresses two issues:

#2205 - For uploads the number of upload threads must be known.  For PRC transfers with multiprocess uploads, only the first process is setting the keyword for the number of threads.  Since these are multiple processes, this information needs to be saved in multiprocess shared memory so other processes know the correct number of transfer threads/processes.

I created a new shared data segment for the s3 resource which is separate from the s3 transport's shared memory.  I renamed the transport's shared memory so that it is clear which is which.

To know when shared memory can be cleaned up, a counter was added to track the number of closes.  Once the close counter reaches the number of threads the shared memory is cleaned up.  I have verified that when running the test suite all shared memory files are cleaned up as expected.

Note that an up/down counter tracking create/open and closes will not work as the shared memory must be created before the first create/open and with an up/down counter this counter would immediately be zero and the shared memory would be deleted.

Read operations do not need this shared memory as we don't need to know the number of threads/processes in that case.  In addition, the number of threads is not reliable in that scenario so it would be difficult to determine when the shared memory can be cleaned up.

I also learned via testing that our mechanism to calculate the necessary shared memory sizes is not accurate as the boost libraries need an unspecified amount of overhead memory.  It was suggested that `100*sizeof(void*)` bytes is plenty for this so I added this extra into both the new shared memory and the existing transport's shared memory.

Finally, I wrapped most of the `get_number_of_threads_data_size_and_opr_type()` processing within the shared memory's `atomic_exec()` as it simplifies everything if this part of the code is atomically executed.  A lot of the changes below are simply a result of changing the indentation because of this.

#2207 - I updated the code to use the test case name in filenames that are created.

Tests passed.