### PR TITLE
[2211,2212,2213] Testing fixes (4-3-stable)

### DIFF
--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -33,7 +33,8 @@ def get_package_type():
     return pt
 
 def install_test_prerequisites():
-    irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', '--upgrade', 'pip>=20.3.4'], check_rc=True)
+    if distro.id() != "ubuntu" or int(distro.major_version()) < 24:
+        irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', '--upgrade', 'pip>=20.3.4'], check_rc=True)
     irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', 'boto3', '--upgrade'], check_rc=True)
 
     # Minio 7.1.17 imports the annontations module which only exists in Python 3.7 and beyond.
@@ -42,7 +43,6 @@ def install_test_prerequisites():
     minio_version = '==7.1.16' if sys.hexversion < 0x030700F0 else ''
     irods_python_ci_utilities.subprocess_get_output(['sudo', 'python3', '-m', 'pip', 'install', 'minio' + minio_version, '--upgrade'], check_rc=True)
 
-    irods_python_ci_utilities.subprocess_get_output(['sudo', '-EH', 'python3', '-m', 'pip', 'install', 'unittest-xml-reporting==1.14.0'])
 
 def download_and_start_minio_server():
     path_to_minio = os.path.abspath('minio')

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -1602,7 +1602,7 @@ OUTPUT ruleExecOut
 
         self.admin.assert_icommand("ireg -r /%s/basedir %s/basedir" % (self.s3bucketname, self.admin.session_collection))
         file_count = self.admin.run_icommand('''iquest "%s" "SELECT count(DATA_ID) where COLL_NAME like '%/basedir%'"''')[0]
-        self.assertEquals(file_count, u'9\n')
+        self.assertEqual(file_count, u'9\n')
 
     def test_copy_file_greater_than_chunk_size(self):
 


### PR DESCRIPTION
Replace all instances of assertEquals with assertEqual 
Do not install unittest-xml-reporting==1.14.0
Version-sniff to avoid upgrading pip on Ubuntu 24 and later

Needed for testing. Tests pass.