### PR TITLE
[#2225] Change expected error code in test (4-3-stable)

### DIFF
--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -1559,7 +1559,7 @@ OUTPUT ruleExecOut
         try:
 
             # put small file
-            self.admin.assert_icommand("iput %s" % file1, 'STDERR_SINGLELINE', 'USER_SOCK_CONNECT_ERR')  # iput
+            self.admin.assert_icommand("iput %s" % file1, 'STDERR_SINGLELINE', 'USER_SOCK_CONNECT_TIMEDOUT')  # iput
 
         finally:
 


### PR DESCRIPTION
This change to the test allows a full test run to pass against iRODS 4.3.4.

Still need to determine what caused a change in the error code.