### PR TITLE
[irods/externals#263] Update build hook for clang 16 (main)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -36,18 +36,14 @@ def install_building_dependencies(externals_directory):
     # externals are being supplied via externals_directory, only the externals packages which exist in that directory
     # will be installed.
     externals_list = [
-        'irods-externals-avro1.11.0-3',
-        'irods-externals-boost1.81.0-1',
+        'irods-externals-boost1.81.0-2',
         'irods-externals-catch22.13.8-0',
-        'irods-externals-clang13.0.1-0',
+        'irods-externals-clang16.0.6-0',
         'irods-externals-cmake3.21.4-0',
-        'irods-externals-cppzmq4.8.1-1',
-        'irods-externals-fmt8.1.1-1',
+        'irods-externals-fmt8.1.1-2',
         'irods-externals-json3.10.4-0',
-        'irods-externals-libarchive3.5.2-0',
-        'irods-externals-nanodbc2.13.0-2',
-        'irods-externals-spdlog1.9.2-2',
-        'irods-externals-zeromq4-14.1.8-1'
+        'irods-externals-nanodbc2.13.0-3',
+        'irods-externals-spdlog1.9.2-3'
     ]
     if externals_directory == 'None' or externals_directory is None:
         irods_python_ci_utilities.install_irods_core_dev_repository()


### PR DESCRIPTION
In service of irods/externals#263

Do not merge before new externals packages are in the package repos.