### PR TITLE
[2285][2284] Added sending CRC64/NVME checksum with uploads (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ AWS by default calculates and stores the CRC64/NVME checksum. To make sure that 
 - If the client is validating the checksum (for example "iput -K") then the client should set the `irods_default_hash_scheme` to "crc64nvme".
 - If the client is not validating the checksum (for example "iput -k" or "ichksum") then the server's `default_hash_scheme` should be set to "crc64nvme".
 - Refer to [Checksum Configuration](https://docs.irods.org/5.0.2/system_overview/configuration/#checksum-configuration) for more detail on configuring checksums in iRODS.
+- If the CRC64/NVME checksum is not automatically calculated, try setting `ENABLE_TRAILING_CHECKSUM_ON_UPLOAD=1` in the context string. This will send the CRC64/NVME on uploads and may force the S3 appliance to save the checksum.
+
+Note that the `ENABLE_TRAILING_CHECKSUM_ON_UPLOAD` option requires that the S3 appliance supports chunked encoding.  This feature has only been tested on AWS and MinIO and not every version of MinIO supports chunked encoding. It is suggested that uploads for single part and multipart are thoroughly tested when this flag is enabled.
 
 
 ### Example of a baseline resource configuration

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -51,22 +51,13 @@ def install_test_prerequisites():
 
 
 def download_and_start_minio_server():
-    path_to_minio = os.path.abspath('minio')
 
-    # Only download the executable if it's not already here
-    if not os.path.isfile(path_to_minio):
-        if get_package_type() == 'deb':
-            minio_package_file = 'minio_20220526054841.0.0_amd64.deb'
-            subprocess.check_output(['wget', '-q', '--no-check-certificate', 'https://dl.min.io/server/minio/release/linux-amd64/archive/{}'.format(minio_package_file)])
-            subprocess.check_output(['dpkg', '-i', minio_package_file])
-        elif get_package_type() == 'rpm':
-            minio_package_file = 'minio-20220526054841.0.0.x86_64.rpm'
-            subprocess.check_output(['wget', '-q', '--no-check-certificate', 'https://dl.min.io/server/minio/release/linux-amd64/archive/{}'.format(minio_package_file)])
-            subprocess.check_output(['rpm', '--force', '-i', minio_package_file])
-        else:
-            raise Exception('Unknown or invalid OS type.  Can not install minio.')
+    path_to_minio = '/minio'
 
-        path_to_minio = 'minio'
+    # Download the latest MinIO binary directly (supports aws-chunked encoding with trailing checksums)
+    subprocess.check_output(['wget', '-q', '--no-check-certificate', '-O', path_to_minio,
+                             'https://dl.min.io/server/minio/release/linux-amd64/minio'])
+    os.chmod(path_to_minio, os.stat(path_to_minio).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     root_username = ''.join(random.choice(string.ascii_letters) for i in list(range(10)))
     root_password = ''.join(random.choice(string.ascii_letters) for i in list(range(10)))

--- a/libs3/CMakeLists.txt
+++ b/libs3/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
   "${CMAKE_CURRENT_SOURCE_DIR}/src/service_access_logging.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/simplexml.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/util.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/object_chunked.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/request_chunked.c"
 )
 target_link_libraries(
   libs3_obj

--- a/libs3/include/libs3/libs3.h
+++ b/libs3/include/libs3/libs3.h
@@ -381,7 +381,14 @@ typedef enum
 	S3StatusHttpErrorForbidden,
 	S3StatusHttpErrorNotFound,
 	S3StatusHttpErrorConflict,
-	S3StatusHttpErrorUnknown
+	S3StatusHttpErrorUnknown,
+
+    /**
+     * Chunked encoding errors
+    **/
+    S3StatusChunkEncodingError,
+    S3StatusTrailingHeadersError,
+    S3StatusInvalidChunkCallback
 } S3Status;
 
 /**
@@ -923,6 +930,33 @@ typedef struct S3PutProperties
 	 * This optional field sets the storage class on uploads.
 	 **/
 	const char* xAmzStorageClass;
+
+    /**
+     * This optional field sets the x-amz-checksum-algorithm header.
+     * Valid values are CRC32, CRC32C, SHA1, SHA256, or CRC64NVME.
+     **/
+    const char* xAmzChecksumAlgorithm;
+
+    /**
+     * This optional field sets the x-amz-checksum-type header.
+     * Valid values are COMPOSITE or FULL_OBJECT.
+     * NOTE: Only valid for non-chunked uploads. Do NOT use with chunked encoding.
+     **/
+    const char* xAmzChecksumType;
+
+    /**
+     * This optional field declares trailing headers for chunked uploads.
+     * For example: "x-amz-checksum-crc64nvme" to send checksum as trailer.
+     * Sets the x-amz-trailer header.
+     **/
+    const char* xAmzTrailer;
+
+    /**
+     * Decoded content length for chunked uploads. Specifies the actual payload size
+     * before chunk encoding. Set to -1 if unknown, or provide the actual size.
+     * Sets the x-amz-decoded-content-length header when >= 0.
+     **/
+    int64_t xAmzDecodedContentLength;
 
 } S3PutProperties;
 
@@ -2630,6 +2664,7 @@ void S3_complete_multipart_upload(S3BucketContext* bucketContext,
                                   S3MultipartCommitHandler* handler,
                                   const char* upload_id,
                                   int contentLength,
+                                  S3PutProperties* putProperties,
                                   S3RequestContext* requestContext,
                                   int timeoutMs,
                                   void* callbackData);

--- a/libs3/include/libs3/libs3_chunked.h
+++ b/libs3/include/libs3/libs3_chunked.h
@@ -1,0 +1,204 @@
+/**
+ * libs3_chunked.h - Chunked Encoding and Trailing Headers Extension for libs3
+ *
+ * This header extends libs3.h with support for HTTP chunked transfer encoding
+ * and trailing headers.
+ */
+
+#ifndef LIBS3_CHUNKED_H
+#define LIBS3_CHUNKED_H
+
+#include "libs3/libs3.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================
+ * CHUNKED ENCODING AND TRAILING HEADERS CALLBACK TYPES
+ * ======================================================================== */
+
+/**
+ * Chunked data callback
+ *
+ * This callback is invoked repeatedly to retrieve chunks of data for upload.
+ *
+ * @param bufferSize Maximum number of bytes that can be written to buffer
+ * @param buffer Buffer to write chunk data into
+ * @param callbackData User-provided callback data
+ *
+ * @return Number of bytes written (0 = end of stream, -1 = error)
+ */
+typedef int (*S3ChunkedDataCallback)(
+    int bufferSize,
+    char *buffer,
+    void *callbackData);
+
+/**
+ * Trailing headers callback
+ *
+ * This callback is invoked after all data chunks have been sent, allowing
+ * the application to provide additional HTTP headers (trailers) that are
+ * sent after the body content. This is useful for checksums or metadata
+ * that can only be computed after the entire payload has been processed.
+ *
+ * @param maxHeaders Maximum number of headers that can be set
+ * @param headers Array to write trailing headers into
+ * @param callbackData User-provided callback data
+ *
+ * @return Number of headers set (0 = no trailers, -1 = error)
+ */
+typedef int (*S3TrailingHeadersCallback)(
+    int maxHeaders,
+    S3NameValue *headers,
+    void *callbackData);
+
+/**
+ * Chunked PUT object handler
+ *
+ * This handler structure supports chunked transfer encoding and trailing
+ * headers for streaming uploads where the content length is not known
+ * in advance.
+ */
+typedef struct S3PutObjectHandlerChunked
+{
+    S3ResponseHandler responseHandler;
+
+    /* Callback to retrieve data chunks */
+    S3ChunkedDataCallback chunkedDataCallback;
+
+    /* Optional callback to set trailing headers after all chunks sent */
+    S3TrailingHeadersCallback trailingHeadersCallback;
+
+} S3PutObjectHandlerChunked;
+
+/* ========================================================================
+ * FUNCTION DECLARATIONS
+ * ======================================================================== */
+
+/**
+ * PUT object with chunked encoding
+ *
+ * This function performs a PUT operation using HTTP chunked transfer encoding.
+ * The content length is not specified in advance; instead, data is provided
+ * through the chunkedDataCallback which is called repeatedly until it returns 0.
+ *
+ * Optionally, trailing headers can be sent after all chunks by providing a
+ * trailingHeadersCallback. This is useful for checksums or metadata computed
+ * during the upload process.
+ *
+ * @param bucketContext S3 bucket context
+ * @param key Object key
+ * @param putProperties PUT properties (content-type, metadata, etc.)
+ * @param requestContext Request context (NULL for synchronous operation)
+ * @param timeoutMs Operation timeout in milliseconds (0 = no timeout)
+ * @param handler Chunked PUT handler with callbacks
+ * @param callbackData User data passed to callbacks
+ */
+void S3_put_object_chunked(const S3BucketContext *bucketContext,
+                           const char *key,
+                           const S3PutProperties *putProperties,
+                           S3RequestContext *requestContext,
+                           int timeoutMs,
+                           const S3PutObjectHandlerChunked *handler,
+                           void *callbackData);
+
+/**
+ * Upload multipart part with chunked encoding
+ *
+ * This function uploads a single part of a multipart upload using HTTP chunked
+ * transfer encoding with optional trailing headers. This is useful for streaming
+ * uploads where trailing checksums are needed.
+ *
+ * @param bucketContext S3 bucket context
+ * @param key Object key
+ * @param putProperties PUT properties (content-type, metadata, etc.)
+ * @param seq Part sequence number (1-based)
+ * @param uploadId Multipart upload ID from initiate multipart upload
+ * @param requestContext Request context (NULL for synchronous operation)
+ * @param timeoutMs Operation timeout in milliseconds (0 = no timeout)
+ * @param handler Chunked PUT handler with callbacks
+ * @param callbackData User data passed to callbacks
+ */
+void S3_upload_part_chunked(const S3BucketContext *bucketContext,
+                            const char *key,
+                            const S3PutProperties *putProperties,
+                            int seq,
+                            const char *uploadId,
+                            S3RequestContext *requestContext,
+                            int timeoutMs,
+                            const S3PutObjectHandlerChunked *handler,
+                            void *callbackData);
+
+/* ========================================================================
+ * INTERNAL CHUNKED ENCODING FUNCTIONS
+ * ======================================================================== */
+
+/**
+ * Opaque chunked request state structure
+ * Implementation details are hidden in request_chunked.c
+ */
+typedef struct ChunkedRequestState ChunkedRequestState;
+
+/**
+ * Create chunked request state
+ *
+ * @param statePtr Output parameter for created state
+ * @param chunkedCallback Callback to retrieve data chunks
+ * @param trailingCallback Optional callback for trailing headers
+ * @param callbackData User data passed to callbacks
+ * @return S3StatusOK on success, error code otherwise
+ */
+S3Status S3_create_chunked_request_state(ChunkedRequestState **statePtr,
+                                        S3ChunkedDataCallback chunkedCallback,
+                                        S3TrailingHeadersCallback trailingCallback,
+                                        void *callbackData);
+
+/**
+ * Destroy chunked request state
+ *
+ * @param state State to destroy
+ */
+void S3_destroy_chunked_request_state(ChunkedRequestState *state);
+
+/**
+ * Check if chunked request has error
+ *
+ * @param state Chunked request state
+ * @return 1 if error occurred, 0 otherwise
+ */
+int S3_chunked_request_has_error(const ChunkedRequestState *state);
+
+/**
+ * Setup CURL for chunked encoding
+ *
+ * @param curl CURL handle (void* to avoid exposing CURL* in public API)
+ * @param state Chunked request state
+ * @return S3StatusOK on success, error code otherwise
+ */
+S3Status request_setup_chunked_encoding(void *curl, ChunkedRequestState *state);
+
+/**
+ * Set signature information for trailing header signing
+ *
+ * This must be called from request.c after computing the request signature
+ * to enable x-amz-trailer-signature calculation for STREAMING-UNSIGNED-PAYLOAD-TRAILER.
+ *
+ * @param state Chunked request state
+ * @param seedSignature Hex signature from Authorization header (64 chars + null)
+ * @param timestamp Request timestamp in ISO8601 format
+ * @param credentialScope Credential scope (date/region/service/aws4_request)
+ * @param signingKey AWS4 signing key (32 bytes)
+ * @return S3StatusOK on success, error code otherwise
+ */
+S3Status chunked_set_signature_info(ChunkedRequestState *state,
+                                   const char *seedSignature,
+                                   const char *timestamp,
+                                   const char *credentialScope,
+                                   const unsigned char *signingKey);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* LIBS3_CHUNKED_H */

--- a/libs3/include/libs3/request.h
+++ b/libs3/include/libs3/request.h
@@ -115,6 +115,12 @@ typedef struct RequestParams
 	 * This optional field sets the list of object attributes for GetObjectAttributes.
 	 **/
 	const char* xAmzObjectAttributes;
+
+	/**
+	 * Opaque pointer to chunked request state for chunked encoding with trailing headers.
+	 * When set, enables chunked transfer encoding with trailing header support.
+	 **/
+	void* chunkedState;
 } RequestParams;
 
 // This is the stuff associated with a request that needs to be on the heap

--- a/libs3/src/bucket.c
+++ b/libs3/src/bucket.c
@@ -158,7 +158,8 @@ void S3_test_bucket(S3Protocol protocol,
 		&testBucketCompleteCallback,   // completeCallback
 		tbData,                        // callbackData
 		timeoutMs,                     // timeoutMs
-		0                              // xAmzObjectAttributes
+		0,                             // xAmzObjectAttributes
+		0                              // chunkedState
 	};
 
 	// Perform the request
@@ -279,7 +280,11 @@ void S3_create_bucket(S3Protocol protocol,
 		0,         // metaDataCount
 		0,         // metaData
 		0,         // useServerSideEncryption
-		0          // xAmzStorageClass
+		0,         // xAmzStorageClass
+        0,         // xAmzChecksumAlgorithm
+        0,         // xAmzChecksumType
+        0,         // xAmzTrailer
+        -1         // xAmzDecodedContentLength (-1 = unknown)
 	};
 
 	// Set up the RequestParams
@@ -310,7 +315,8 @@ void S3_create_bucket(S3Protocol protocol,
 		&createBucketCompleteCallback,   // completeCallback
 		cbData,                          // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -397,7 +403,8 @@ void S3_delete_bucket(S3Protocol protocol,
 		&deleteBucketCompleteCallback,   // completeCallback
 		dbData,                          // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -725,7 +732,8 @@ void S3_list_bucket(const S3BucketContext* bucketContext,
 		&listBucketCompleteCallback,      // completeCallback
 		lbData,                           // callbackData
 		timeoutMs,                        // timeoutMs
-		0                                 // xAmzObjectAttributes
+		0,                                // xAmzObjectAttributes
+		0                                 // chunkedState
 	};
 
 	// Perform the request

--- a/libs3/src/bucket_metadata.c
+++ b/libs3/src/bucket_metadata.c
@@ -156,7 +156,8 @@ void S3_get_acl(const S3BucketContext* bucketContext,
 		&getAclCompleteCallback,         // completeCallback
 		gaData,                          // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -353,7 +354,8 @@ void S3_set_acl(const S3BucketContext* bucketContext,
 		&setXmlCompleteCallback,         // completeCallback
 		data,                            // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -455,7 +457,8 @@ void S3_get_lifecycle(const S3BucketContext* bucketContext,
 		&getLifecycleCompleteCallback,   // completeCallback
 		gaData,                          // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -545,7 +548,11 @@ void S3_set_lifecycle(const S3BucketContext* bucketContext,
 		0,         // metaDataCount
 		0,         // metaData
 		0,         // useServerSideEncryption
-		0          // xAmzStorageClass
+		0,         // xAmzStorageClass
+        0,         // xAmzChecksumAlgorithm
+        0,         // xAmzChecksumType
+        0,         // xAmzTrailer
+        -1         // xAmzDecodedContentLength (-1 = unknown)
 	};
 
 	// Set up the RequestParams
@@ -576,7 +583,8 @@ void S3_set_lifecycle(const S3BucketContext* bucketContext,
 		&setXmlCompleteCallback,         // completeCallback
 		data,                            // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request

--- a/libs3/src/general.c
+++ b/libs3/src/general.c
@@ -198,6 +198,9 @@ const char* S3_get_status_name(S3Status status)
 		handlecase(HttpErrorNotFound);
 		handlecase(HttpErrorConflict);
 		handlecase(HttpErrorUnknown);
+		handlecase(ChunkEncodingError);
+		handlecase(TrailingHeadersError);
+		handlecase(InvalidChunkCallback);
 	}
 
 	return "Unknown";

--- a/libs3/src/multipart.c
+++ b/libs3/src/multipart.c
@@ -140,7 +140,8 @@ void S3_initiate_multipart(S3BucketContext* bucketContext,
 		InitialMultipartCompleteCallback,   // completeCallback
 		mdata,                              // callbackData
 		timeoutMs,                          // timeoutMs
-		0                                   // xAmzObjectAttributes
+		0,                                  // xAmzObjectAttributes
+		0                                   // chunkedState
 	};
 
 	// Perform the request
@@ -183,7 +184,8 @@ void S3_abort_multipart_upload(S3BucketContext* bucketContext,
 		AbortMultipartUploadCompleteCallback,        // completeCallback
 		0,                                           // callbackData
 		timeoutMs,                                   // timeoutMs
-		0                                            // xAmzObjectAttributes
+		0,                                           // xAmzObjectAttributes
+		0                                            // chunkedState
 	};
 
 	// Perform the request
@@ -235,7 +237,8 @@ void S3_upload_part(S3BucketContext* bucketContext,
 		handler->responseHandler.completeCallback,   // completeCallback
 		callbackData,                                // callbackData
 		timeoutMs,                                   // timeoutMs
-		0                                            // xAmzObjectAttributes
+		0,                                           // xAmzObjectAttributes
+		0                                            // chunkedState
 	};
 
 	request_perform(&params, requestContext);
@@ -323,6 +326,7 @@ void S3_complete_multipart_upload(S3BucketContext* bucketContext,
                                   S3MultipartCommitHandler* handler,
                                   const char* upload_id,
                                   int contentLength,
+                                  S3PutProperties* putProperties,
                                   S3RequestContext* requestContext,
                                   int timeoutMs,
                                   void* callbackData)
@@ -356,7 +360,7 @@ void S3_complete_multipart_upload(S3BucketContext* bucketContext,
 		0,                                 // getConditions
 		0,                                 // startByte
 		0,                                 // byteCount
-		0,                                 // putProperties
+		putProperties,                     // putProperties
 		commitMultipartPropertiesCallback, // propertiesCallback
 		commitMultipartPutObject,          // toS3Callback
 		contentLength,                     // toS3CallbackTotalSize
@@ -364,7 +368,8 @@ void S3_complete_multipart_upload(S3BucketContext* bucketContext,
 		commitMultipartCompleteCallback,   // completeCallback
 		data,                              // callbackData
 		timeoutMs,                         // timeoutMs
-		0                                  // xAmzObjectAttributes
+		0,                                 // xAmzObjectAttributes
+		0                                  // chunkedState
 	};
 
 	request_perform(&params, requestContext);
@@ -896,7 +901,8 @@ void S3_list_multipart_uploads(S3BucketContext* bucketContext,
 		&listMultipartCompleteCallback,   // completeCallback
 		lmData,                           // callbackData
 		timeoutMs,                        // timeoutMs
-		0                                 // xAmzObjectAttributes
+		0,                                // xAmzObjectAttributes
+		0                                 // chunkedState
 	};
 
 	// Perform the request
@@ -1014,7 +1020,8 @@ void S3_list_parts(S3BucketContext* bucketContext,
 		&listPartsCompleteCallback,       // completeCallback
 		lpData,                           // callbackData
 		timeoutMs,                        // timeoutMs
-		0                                 // xAmzObjectAttributes
+		0,                                // xAmzObjectAttributes
+		0                                 // chunkedState
 	};
 
 	// Perform the request

--- a/libs3/src/object.c
+++ b/libs3/src/object.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#include <strings.h>
 #include "libs3/libs3.h"
 #include "libs3/request.h"
 
@@ -75,7 +76,8 @@ void S3_put_object(const S3BucketContext* bucketContext,
 		handler->responseHandler.completeCallback,   // completeCallback
 		callbackData,                                // callbackData
 		timeoutMs,                                   // timeoutMs
-		0                                            // xAmzObjectAttributes
+		0,                                           // xAmzObjectAttributes
+		0                                            // chunkedState
 	};
 
 	// Perform the request
@@ -271,7 +273,8 @@ void S3_copy_object_range(const S3BucketContext* bucketContext,
 		&copyObjectCompleteCallback,                                        // completeCallback
 		data,                                                               // callbackData
 		timeoutMs,                                                          // timeoutMs
-		0                                                                   // xAmzObjectAttributes
+		0,                                                                  // xAmzObjectAttributes
+		0                                                                   // chunkedState
 	};
 
 	// Perform the request
@@ -318,7 +321,8 @@ void S3_get_object(const S3BucketContext* bucketContext,
 		handler->responseHandler.completeCallback,   // completeCallback
 		callbackData,                                // callbackData
 		timeoutMs,                                   // timeoutMs
-		0                                            // xAmzObjectAttributes
+		0,                                           // xAmzObjectAttributes
+		0                                            // chunkedState
 	};
 
 	// Perform the request
@@ -362,7 +366,8 @@ void S3_head_object(const S3BucketContext* bucketContext,
 		handler->completeCallback,       // completeCallback
 		callbackData,                    // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -406,7 +411,8 @@ void S3_delete_object(const S3BucketContext* bucketContext,
 		handler->completeCallback,       // completeCallback
 		callbackData,                    // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -504,7 +510,8 @@ void S3_restore_object(S3BucketContext* bucketContext,
 		restoreObjectCompleteCallback,   // completeCallback
 		data,                            // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	request_perform(&params, requestContext);
@@ -570,29 +577,31 @@ static S3Status getObjectAttributesXmlCallback(const char* elementPath, const ch
 		return S3StatusOK;
 	}
 
-    // Note that elementPath is a 512 character array
-    if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC32", 511)) {
+    // Note that elementPath is a 512 character array.
+    // Use strncasecmp because MinIO returns <getObjectAttributesResponse> (lowercase 'g')
+    // while AWS returns <GetObjectAttributesResponse> (uppercase 'G').
+    if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC32", 511)) {
         string_buffer_append(goaData->checksumCRC32, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC32C", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC32C", 511)) {
         string_buffer_append(goaData->checksumCRC32C, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC64NVME", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumCRC64NVME", 511)) {
         string_buffer_append(goaData->checksumCRC64NVME, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumSHA1", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumSHA1", 511)) {
         string_buffer_append(goaData->checksumSHA1, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumSHA256", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumSHA256", 511)) {
         string_buffer_append(goaData->checksumSHA256, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumType", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/Checksum/ChecksumType", 511)) {
         string_buffer_append(goaData->checksumType, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/StorageClass", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/StorageClass", 511)) {
         string_buffer_append(goaData->storageClass, data, dataLen, fit);
     }
-    else if (0 == strncmp(elementPath, "GetObjectAttributesResponse/ObjectSize", 511)) {
+    else if (0 == strncasecmp(elementPath, "GetObjectAttributesResponse/ObjectSize", 511)) {
         // Keep this as a string.  User can parse it as a long long if desired.
         string_buffer_append(goaData->objectSize, data, dataLen, fit);
     }
@@ -658,7 +667,8 @@ void S3_get_object_attributes(S3BucketContext* bucketContext,
 		GetObjectAttributesCompleteCallback,   // completeCallback
 		goaData,                               // callbackData
 		timeoutMs,                             // timeoutMs
-		xAmzObjectAttributes                   // xAmzObjectAttributes
+		xAmzObjectAttributes,                  // xAmzObjectAttributes
+		0                                      // chunkedState
 	};
 
 	// Perform the request

--- a/libs3/src/object_chunked.c
+++ b/libs3/src/object_chunked.c
@@ -1,0 +1,266 @@
+/**
+ * object_chunked.c - Chunked Object Upload API Implementation
+ *
+ * This file implements the high-level S3_put_object_chunked() API function
+ * that allows applications to upload objects using HTTP chunked transfer
+ * encoding with optional trailing headers.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include "libs3/libs3_chunked.h"
+#include "libs3/request.h"
+
+/**
+ * Internal context for chunked PUT operation
+ */
+typedef struct ChunkedPutContext
+{
+    /* User callbacks and data */
+    const S3PutObjectHandlerChunked *handler;
+    void *callbackData;
+
+    /* Chunked request state */
+    ChunkedRequestState *chunkedState;
+
+    /* Status */
+    S3Status status;
+} ChunkedPutContext;
+
+/**
+ * Wrapper callback for chunked data
+ *
+ * This wrapper adapts the chunked data callback to the standard
+ * S3PutObjectDataCallback signature expected by RequestParams.
+ */
+static int chunked_data_wrapper(int bufferSize, char *buffer, void *callbackData)
+{
+    ChunkedPutContext *context = (ChunkedPutContext *)callbackData;
+
+    if (!context || !context->handler || !context->handler->chunkedDataCallback) {
+        return -1;
+    }
+
+    return context->handler->chunkedDataCallback(bufferSize, buffer, context->callbackData);
+}
+
+/**
+ * Response properties callback wrapper
+ *
+ * Forwards response properties to user's callback if provided.
+ */
+static S3Status chunked_put_properties_callback(
+    const S3ResponseProperties *properties,
+    void *callbackData)
+{
+    ChunkedPutContext *context = (ChunkedPutContext *)callbackData;
+
+    if (context->handler &&
+        context->handler->responseHandler.propertiesCallback) {
+        return context->handler->responseHandler.propertiesCallback(
+            properties, context->callbackData);
+    }
+
+    return S3StatusOK;
+}
+
+/**
+ * Response complete callback wrapper
+ *
+ * Cleans up chunked state and forwards completion to user's callback.
+ */
+static void chunked_put_complete_callback(
+    S3Status status,
+    const S3ErrorDetails *error,
+    void *callbackData)
+{
+    ChunkedPutContext *context = (ChunkedPutContext *)callbackData;
+
+    /* Check if chunked transfer had errors */
+    if (status == S3StatusOK && context->chunkedState) {
+        if (S3_chunked_request_has_error(context->chunkedState)) {
+            status = S3StatusChunkEncodingError;
+        }
+    }
+
+    /* Store final status */
+    context->status = status;
+
+    /* Call user's completion callback */
+    if (context->handler &&
+        context->handler->responseHandler.completeCallback) {
+        context->handler->responseHandler.completeCallback(
+            status, error, context->callbackData);
+    }
+
+    /* Cleanup chunked state */
+    if (context->chunkedState) {
+        S3_destroy_chunked_request_state(context->chunkedState);
+        context->chunkedState = NULL;
+    }
+}
+
+void S3_put_object_chunked(const S3BucketContext *bucketContext,
+                           const char *key,
+                           const S3PutProperties *putProperties,
+                           S3RequestContext *requestContext,
+                           int timeoutMs,
+                           const S3PutObjectHandlerChunked *handler,
+                           void *callbackData)
+{
+    ChunkedPutContext context;  /* Stack-allocated for thread safety */
+    S3Status status;
+
+    /* Validate inputs */
+    if (!bucketContext || !key || !handler || !handler->chunkedDataCallback) {
+        if (handler && handler->responseHandler.completeCallback) {
+            handler->responseHandler.completeCallback(
+                S3StatusInvalidChunkCallback, NULL, callbackData);
+        }
+        return;
+    }
+
+    /* Initialize context */
+    memset(&context, 0, sizeof(ChunkedPutContext));
+    context.handler = handler;
+    context.callbackData = callbackData;
+    context.status = S3StatusOK;
+
+    /* Create chunked request state
+     * AWS S3 DOES support trailing headers, but they must be declared using x-amz-trailer header
+     */
+    status = S3_create_chunked_request_state(
+        &context.chunkedState,
+        handler->chunkedDataCallback,
+        handler->trailingHeadersCallback,  // Re-enable trailing headers support
+        callbackData
+    );
+
+    if (status != S3StatusOK) {
+        if (handler->responseHandler.completeCallback) {
+            handler->responseHandler.completeCallback(status, NULL, callbackData);
+        }
+        return;
+    }
+
+    /* Set up the RequestParams - use Transfer-Encoding: chunked (toS3CallbackTotalSize = -1) */
+    RequestParams params = {
+        HttpRequestTypePUT,                          // httpRequestType
+        {bucketContext->hostName,                    // hostName
+         bucketContext->bucketName,                  // bucketName
+         bucketContext->protocol,                    // protocol
+         bucketContext->uriStyle,                    // uriStyle
+         bucketContext->accessKeyId,                 // accessKeyId
+         bucketContext->secretAccessKey,             // secretAccessKey
+         bucketContext->securityToken,               // securityToken
+         bucketContext->authRegion,                  // authRegion
+         bucketContext->stsDate},                    // stsDate
+        key,                                         // key
+        0,                                           // queryParams
+        0,                                           // subResource
+        0,                                           // copySourceBucketName
+        0,                                           // copySourceKey
+        0,                                           // getConditions
+        0,                                           // startByte
+        0,                                           // byteCount
+        putProperties,                               // putProperties
+        chunked_put_properties_callback,             // propertiesCallback
+        chunked_data_wrapper,                        // toS3Callback
+        -1,                                          // toS3CallbackTotalSize (-1 = chunked encoding)
+        0,                                           // fromS3Callback
+        chunked_put_complete_callback,               // completeCallback
+        &context,                                    // callbackData
+        timeoutMs,                                   // timeoutMs
+        0,                                           // xAmzObjectAttributes
+        context.chunkedState                         // chunkedState (for trailing headers)
+    };
+
+    /* Perform the request
+     * The request infrastructure will call our chunked_data_wrapper callback
+     * to get data, which will in turn call the user's chunkedDataCallback.
+     */
+    request_perform(&params, requestContext);
+}
+
+void S3_upload_part_chunked(const S3BucketContext *bucketContext,
+                            const char *key,
+                            const S3PutProperties *putProperties,
+                            int seq,
+                            const char *uploadId,
+                            S3RequestContext *requestContext,
+                            int timeoutMs,
+                            const S3PutObjectHandlerChunked *handler,
+                            void *callbackData)
+{
+    ChunkedPutContext context;  /* Stack-allocated for thread safety */
+    S3Status status;
+    char queryParams[512];
+
+    /* Build query parameters for multipart upload */
+    snprintf(queryParams, sizeof(queryParams), "partNumber=%d&uploadId=%s", seq, uploadId);
+
+    /* Validate inputs */
+    if (!bucketContext || !key || !handler || !handler->chunkedDataCallback || !uploadId) {
+        if (handler && handler->responseHandler.completeCallback) {
+            handler->responseHandler.completeCallback(
+                S3StatusInvalidChunkCallback, NULL, callbackData);
+        }
+        return;
+    }
+
+    /* Initialize context */
+    memset(&context, 0, sizeof(ChunkedPutContext));
+    context.handler = handler;
+    context.callbackData = callbackData;
+    context.status = S3StatusOK;
+
+    /* Create chunked request state with trailing headers support */
+    status = S3_create_chunked_request_state(
+        &context.chunkedState,
+        handler->chunkedDataCallback,
+        handler->trailingHeadersCallback,
+        callbackData
+    );
+
+    if (status != S3StatusOK) {
+        if (handler->responseHandler.completeCallback) {
+            handler->responseHandler.completeCallback(status, NULL, callbackData);
+        }
+        return;
+    }
+
+    /* Set up the RequestParams - use Transfer-Encoding: chunked (toS3CallbackTotalSize = -1) */
+    RequestParams params = {
+        HttpRequestTypePUT,                          // httpRequestType
+        {bucketContext->hostName,                    // hostName
+         bucketContext->bucketName,                  // bucketName
+         bucketContext->protocol,                    // protocol
+         bucketContext->uriStyle,                    // uriStyle
+         bucketContext->accessKeyId,                 // accessKeyId
+         bucketContext->secretAccessKey,             // secretAccessKey
+         bucketContext->securityToken,               // securityToken
+         bucketContext->authRegion,                  // authRegion
+         bucketContext->stsDate},                    // stsDate
+        key,                                         // key
+        queryParams,                                 // queryParams (partNumber & uploadId)
+        0,                                           // subResource
+        0,                                           // copySourceBucketName
+        0,                                           // copySourceKey
+        0,                                           // getConditions
+        0,                                           // startByte
+        0,                                           // byteCount
+        putProperties,                               // putProperties
+        chunked_put_properties_callback,             // propertiesCallback
+        chunked_data_wrapper,                        // toS3Callback
+        -1,                                          // toS3CallbackTotalSize (-1 = chunked encoding)
+        0,                                           // fromS3Callback
+        chunked_put_complete_callback,               // completeCallback
+        &context,                                    // callbackData
+        timeoutMs,                                   // timeoutMs
+        0,                                           // xAmzObjectAttributes
+        context.chunkedState                         // chunkedState (for trailing headers)
+    };
+
+    /* Perform the request */
+    request_perform(&params, requestContext);
+}

--- a/libs3/src/request_chunked.c
+++ b/libs3/src/request_chunked.c
@@ -1,0 +1,719 @@
+/**
+ * request_chunked.c - Chunked Encoding Implementation for libs3
+ *
+ * This file implements HTTP chunked transfer encoding and trailing headers
+ * support for the libs3 library.
+ *
+ * Copyright 2024
+ * Based on original libs3 code Copyright 2008 Bryan Ischo <bryan@ischo.com>
+ *
+ * Licensed under LGPL v3 or GPL v2 (same as original libs3)
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <curl/curl.h>
+#include "libs3/libs3_chunked.h"
+#include "libs3/request.h"
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#define S3_SHA256_DIGEST_LENGTH SHA256_DIGEST_LENGTH
+
+/* Default chunk buffer size (64KB) */
+#define DEFAULT_CHUNK_BUFFER_SIZE (64 * 1024)
+
+/* Maximum trailing header line length */
+#define MAX_TRAILER_LINE_LENGTH 512
+
+/**
+ * Chunked request state structure
+ *
+ * This structure tracks the state of a chunked transfer encoding request,
+ * including buffers, callbacks, and trailing header information.
+ */
+typedef enum {
+    CHUNK_STATE_HEADER,      /* Sending chunk size header: "XXXX\r\n" */
+    CHUNK_STATE_DATA,        /* Sending chunk data */
+    CHUNK_STATE_DATA_END,    /* Sending "\r\n" after chunk data */
+    CHUNK_STATE_FINAL,       /* Sending final "0\r\n" */
+    CHUNK_STATE_TRAILERS,    /* Sending trailing headers */
+    CHUNK_STATE_DONE         /* All done */
+} ChunkPhase;
+
+typedef struct ChunkedRequestState
+{
+    /* Callbacks */
+    S3ChunkedDataCallback chunkedDataCallback;
+    S3TrailingHeadersCallback trailingHeadersCallback;
+    void *callbackData;
+
+    /* Chunk buffer */
+    char *chunkBuffer;
+    int chunkBufferSize;
+    int chunkBufferUsed;    /* Bytes currently in buffer */
+    int chunkBufferOffset;  /* Read position in buffer */
+
+    /* Manual chunking state */
+    ChunkPhase phase;
+    char chunkHeader[32];    /* Buffer for chunk size header like "1000\r\n" */
+    int chunkHeaderLen;
+    int chunkHeaderOffset;
+    char trailerBuffer[1024]; /* Buffer for formatted trailing headers */
+    int trailerBufferLen;
+    int trailerBufferOffset;
+
+    /* State flags */
+    int allChunksSent;
+    int trailingHeadersGenerated;
+    int errorOccurred;
+
+    /* Trailing headers */
+    S3NameValue trailingHeaders[S3_MAX_METADATA_COUNT];
+    int trailingHeadersCount;
+
+    /* Statistics */
+    uint64_t totalBytesSent;
+
+    /* Signature information for trailing headers */
+    char seedSignature[65];           /* Hex signature from Authorization header */
+    char requestDateISO8601[64];      /* Request timestamp */
+    char credentialScope[128];        /* Date/region/service/aws4_request */
+    unsigned char signingKey[32];     /* AWS4 signing key */
+    int hasSignatureInfo;             /* 1 if signature info is populated */
+} ChunkedRequestState;
+
+/**
+ * Compute SHA256 hash and return as hex string
+ *
+ * @param data Data to hash
+ * @param len Length of data
+ * @param hexOutput Buffer for hex output (must be at least 65 bytes)
+ */
+static void compute_sha256_hex(const unsigned char *data, size_t len, char *hexOutput)
+{
+    unsigned char hash[S3_SHA256_DIGEST_LENGTH];
+
+    SHA256(data, len, hash);
+
+    for (int i = 0; i < S3_SHA256_DIGEST_LENGTH; i++) {
+        sprintf(hexOutput + (i * 2), "%02x", hash[i]);
+    }
+    hexOutput[S3_SHA256_DIGEST_LENGTH * 2] = '\0';
+}
+
+/**
+ * Compute HMAC-SHA256 signature
+ *
+ * @param key Signing key
+ * @param keyLen Length of signing key
+ * @param data Data to sign
+ * @param dataLen Length of data
+ * @param output Buffer for output (must be at least S3_SHA256_DIGEST_LENGTH bytes)
+ */
+static void compute_hmac_sha256(const unsigned char *key, size_t keyLen,
+                                const unsigned char *data, size_t dataLen,
+                                unsigned char *output)
+{
+    HMAC(EVP_sha256(), key, (int)keyLen, data, dataLen, output, NULL);
+}
+
+/**
+ * Compute HMAC-SHA256 signature and return as hex string
+ *
+ * @param key Signing key
+ * @param keyLen Length of signing key
+ * @param data Data to sign
+ * @param dataLen Length of data
+ * @param hexOutput Buffer for hex output (must be at least 65 bytes)
+ */
+static void compute_hmac_sha256_hex(const unsigned char *key, size_t keyLen,
+                                    const unsigned char *data, size_t dataLen,
+                                    char *hexOutput)
+{
+    unsigned char signature[S3_SHA256_DIGEST_LENGTH];
+    compute_hmac_sha256(key, keyLen, data, dataLen, signature);
+
+    for (int i = 0; i < S3_SHA256_DIGEST_LENGTH; i++) {
+        sprintf(hexOutput + (i * 2), "%02x", signature[i]);
+    }
+    hexOutput[S3_SHA256_DIGEST_LENGTH * 2] = '\0';
+}
+
+/**
+ * Calculate AWS4-HMAC-SHA256-TRAILER signature for trailing headers
+ *
+ * @param state Chunked request state with signature information
+ * @param trailingHeadersStr Formatted trailing headers string
+ * @param signatureHex Output buffer for hex signature (must be at least 65 bytes)
+ * @return S3StatusOK on success, error otherwise
+ */
+static S3Status calculate_trailer_signature(ChunkedRequestState *state,
+                                            const char *trailingHeadersStr,
+                                            char *signatureHex)
+{
+    if (!state->hasSignatureInfo) {
+        return S3StatusInternalError;
+    }
+
+    /* Compute SHA256 hash of trailing headers */
+    char hashedTrailers[65];
+    compute_sha256_hex((const unsigned char *)trailingHeadersStr,
+                      strlen(trailingHeadersStr),
+                      hashedTrailers);
+
+    /* Build string to sign:
+     * AWS4-HMAC-SHA256-TRAILER\n
+     * <timestamp>\n
+     * <credential-scope>\n
+     * <previous-signature>\n
+     * <hashed-trailer-headers>
+     */
+    char stringToSign[1024];
+    int len = snprintf(stringToSign, sizeof(stringToSign),
+                      "AWS4-HMAC-SHA256-TRAILER\n%s\n%s\n%s\n%s",
+                      state->requestDateISO8601,
+                      state->credentialScope,
+                      state->seedSignature,
+                      hashedTrailers);
+
+    if (len >= (int)sizeof(stringToSign)) {
+        return S3StatusInternalError;
+    }
+
+    /* Compute HMAC-SHA256 using signing key */
+    compute_hmac_sha256_hex(state->signingKey, S3_SHA256_DIGEST_LENGTH,
+                           (const unsigned char *)stringToSign, len,
+                           signatureHex);
+
+    return S3StatusOK;
+}
+
+/**
+ * Initialize chunked request state
+ *
+ * @param state Pointer to state structure to initialize
+ * @param chunkedCallback Callback for retrieving chunk data
+ * @param trailingCallback Optional callback for trailing headers
+ * @param callbackData User data passed to callbacks
+ * @param bufferSize Size of chunk buffer to allocate
+ *
+ * @return S3StatusOK on success, error code otherwise
+ */
+static S3Status chunked_state_initialize(ChunkedRequestState *state,
+                                        S3ChunkedDataCallback chunkedCallback,
+                                        S3TrailingHeadersCallback trailingCallback,
+                                        void *callbackData,
+                                        int bufferSize)
+{
+    if (!state || !chunkedCallback) {
+        return S3StatusInvalidChunkCallback;
+    }
+
+    memset(state, 0, sizeof(ChunkedRequestState));
+
+    state->chunkedDataCallback = chunkedCallback;
+    state->trailingHeadersCallback = trailingCallback;
+    state->callbackData = callbackData;
+    state->chunkBufferSize = (bufferSize > 0) ? bufferSize : DEFAULT_CHUNK_BUFFER_SIZE;
+
+    state->chunkBuffer = (char *)malloc(state->chunkBufferSize);
+    if (!state->chunkBuffer) {
+        return S3StatusOutOfMemory;
+    }
+
+    state->chunkBufferUsed = 0;
+    state->chunkBufferOffset = 0;
+    state->phase = CHUNK_STATE_HEADER;  /* Start with chunk header */
+    state->chunkHeaderLen = 0;
+    state->chunkHeaderOffset = 0;
+    state->trailerBufferLen = 0;
+    state->trailerBufferOffset = 0;
+    state->allChunksSent = 0;
+    state->trailingHeadersGenerated = 0;
+    state->errorOccurred = 0;
+    state->trailingHeadersCount = 0;
+    state->totalBytesSent = 0;
+
+    return S3StatusOK;
+}
+
+/**
+ * Cleanup chunked request state
+ *
+ * @param state Pointer to state structure to cleanup
+ */
+static void chunked_state_cleanup(ChunkedRequestState *state)
+{
+    if (!state) {
+        return;
+    }
+
+    if (state->chunkBuffer) {
+        free(state->chunkBuffer);
+        state->chunkBuffer = NULL;
+    }
+
+    memset(state, 0, sizeof(ChunkedRequestState));
+}
+
+/**
+ * Read callback for libcurl - provides MANUALLY formatted AWS chunked data
+ *
+ * This callback manually formats data in AWS chunked encoding format:
+ * <size-hex>\r\n<data>\r\n...<size-hex>\r\n<data>\r\n0\r\n<trailers>\r\n\r\n
+ *
+ * @param ptr Buffer to write data into
+ * @param size Size of each element
+ * @param nmemb Number of elements
+ * @param userdata Pointer to ChunkedRequestState
+ *
+ * @return Number of bytes written, 0 for EOF, CURL_READFUNC_ABORT for error
+ */
+static size_t chunked_read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    ChunkedRequestState *state = (ChunkedRequestState *)userdata;
+    size_t maxBytes = size * nmemb;
+    size_t totalWritten = 0;
+    char *output = (char *)ptr;
+
+    if (!state || state->errorOccurred) {
+        return CURL_READFUNC_ABORT;
+    }
+
+    while (totalWritten < maxBytes && state->phase != CHUNK_STATE_DONE) {
+        switch (state->phase) {
+            case CHUNK_STATE_HEADER: {
+                /* Need to read data and format chunk header */
+                if (state->chunkBufferOffset >= state->chunkBufferUsed) {
+                    /* Buffer empty, read more data */
+                    int bytesRead = state->chunkedDataCallback(
+                        state->chunkBufferSize,
+                        state->chunkBuffer,
+                        state->callbackData
+                    );
+
+                    if (bytesRead < 0) {
+                        state->errorOccurred = 1;
+                        return CURL_READFUNC_ABORT;
+                    }
+
+                    if (bytesRead == 0) {
+                        /* EOF - move to final chunk */
+                        state->phase = CHUNK_STATE_FINAL;
+                        continue;
+                    }
+
+                    state->chunkBufferUsed = bytesRead;
+                    state->chunkBufferOffset = 0;
+                }
+
+                /* Format chunk header: "<size-hex>\r\n" */
+                int dataSize = state->chunkBufferUsed - state->chunkBufferOffset;
+                state->chunkHeaderLen = snprintf(state->chunkHeader, sizeof(state->chunkHeader),
+                                                 "%x\r\n", dataSize);
+                state->chunkHeaderOffset = 0;
+                state->phase = CHUNK_STATE_DATA;
+                break;
+            }
+
+            case CHUNK_STATE_DATA: {
+                /* First send the chunk header if not done yet */
+                if (state->chunkHeaderOffset < state->chunkHeaderLen) {
+                    size_t headerRemaining = state->chunkHeaderLen - state->chunkHeaderOffset;
+                    size_t toCopy = (maxBytes - totalWritten < headerRemaining) ?
+                                    maxBytes - totalWritten : headerRemaining;
+                    memcpy(output + totalWritten,
+                           state->chunkHeader + state->chunkHeaderOffset, toCopy);
+                    state->chunkHeaderOffset += toCopy;
+                    totalWritten += toCopy;
+                    if (state->chunkHeaderOffset < state->chunkHeaderLen) {
+                        break; /* Need more space, return what we have */
+                    }
+                }
+
+                /* Send chunk data */
+                size_t dataRemaining = state->chunkBufferUsed - state->chunkBufferOffset;
+                size_t toCopy = (maxBytes - totalWritten < dataRemaining) ?
+                                maxBytes - totalWritten : dataRemaining;
+
+                if (toCopy > 0) {
+                    memcpy(output + totalWritten,
+                           state->chunkBuffer + state->chunkBufferOffset, toCopy);
+                    state->chunkBufferOffset += toCopy;
+                    state->totalBytesSent += toCopy;
+                    totalWritten += toCopy;
+                }
+
+                if (state->chunkBufferOffset >= state->chunkBufferUsed) {
+                    /* Done with this chunk data, send trailing \r\n */
+                    state->phase = CHUNK_STATE_DATA_END;
+                }
+                break;
+            }
+
+            case CHUNK_STATE_DATA_END: {
+                /* Send "\r\n" after chunk data */
+                const char *end = "\r\n";
+                size_t endLen = 2;
+                size_t toCopy = (maxBytes - totalWritten < endLen) ? maxBytes - totalWritten : endLen;
+                memcpy(output + totalWritten, end, toCopy);
+                totalWritten += toCopy;
+
+                /* Move back to header for next chunk */
+                state->phase = CHUNK_STATE_HEADER;
+                state->chunkBufferOffset = 0;
+                state->chunkBufferUsed = 0;
+                break;
+            }
+
+            case CHUNK_STATE_FINAL: {
+                /* Send final "0\r\n" chunk */
+                const char *final = "0\r\n";
+                size_t finalLen = 3;
+                size_t toCopy = (maxBytes - totalWritten < finalLen) ? maxBytes - totalWritten : finalLen;
+                memcpy(output + totalWritten, final, toCopy);
+                totalWritten += toCopy;
+
+                /* Generate trailing headers */
+                if (state->trailingHeadersCallback && !state->trailingHeadersGenerated) {
+                    state->trailingHeadersCount = state->trailingHeadersCallback(
+                        S3_MAX_METADATA_COUNT,
+                        state->trailingHeaders,
+                        state->callbackData
+                    );
+
+                    if (state->trailingHeadersCount < 0) {
+                        state->errorOccurred = 1;
+                        return CURL_READFUNC_ABORT;
+                    }
+
+                    /* Format trailing headers into buffer (for signature calculation) */
+                    char trailersForSigning[512];
+                    int signingLen = 0;
+
+                    state->trailerBufferLen = 0;
+                    for (int i = 0; i < state->trailingHeadersCount; i++) {
+                        /* Format for buffer (NO space after colon - AWS format) */
+                        int written = snprintf(state->trailerBuffer + state->trailerBufferLen,
+                                             sizeof(state->trailerBuffer) - state->trailerBufferLen,
+                                             "%s:%s\r\n",
+                                             state->trailingHeaders[i].name,
+                                             state->trailingHeaders[i].value);
+                        if (written > 0) {
+                            state->trailerBufferLen += written;
+                        }
+
+                        /* Format for signing (same format, just \n instead of \r\n) */
+                        int sigWritten = snprintf(trailersForSigning + signingLen,
+                                                 sizeof(trailersForSigning) - signingLen,
+                                                 "%s:%s\n",
+                                                 state->trailingHeaders[i].name,
+                                                 state->trailingHeaders[i].value);
+                        if (sigWritten > 0) {
+                            signingLen += sigWritten;
+                        }
+                    }
+
+                    /* FOR UNSIGNED PAYLOAD TRAILERS: Don't send x-amz-trailer-signature */
+                    /* AWS expects trailer signature only for STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER */
+                    /* For STREAMING-UNSIGNED-PAYLOAD-TRAILER, only send the declared checksum trailer */
+
+                    /* Add final \r\n */
+                    if (state->trailerBufferLen + 2 < (int)sizeof(state->trailerBuffer)) {
+                        state->trailerBuffer[state->trailerBufferLen++] = '\r';
+                        state->trailerBuffer[state->trailerBufferLen++] = '\n';
+                    }
+                    state->trailerBufferOffset = 0;
+                    state->trailingHeadersGenerated = 1;
+                }
+
+                state->phase = CHUNK_STATE_TRAILERS;
+                break;
+            }
+
+            case CHUNK_STATE_TRAILERS: {
+                /* Send trailing headers */
+                if (state->trailerBufferOffset < state->trailerBufferLen) {
+                    size_t remaining = state->trailerBufferLen - state->trailerBufferOffset;
+                    size_t toCopy = (maxBytes - totalWritten < remaining) ?
+                                    maxBytes - totalWritten : remaining;
+                    memcpy(output + totalWritten,
+                           state->trailerBuffer + state->trailerBufferOffset, toCopy);
+                    state->trailerBufferOffset += toCopy;
+                    totalWritten += toCopy;
+                } else {
+                    /* All done */
+                    state->phase = CHUNK_STATE_DONE;
+                }
+                break;
+            }
+
+            case CHUNK_STATE_DONE:
+                return totalWritten > 0 ? totalWritten : 0;
+        }
+    }
+
+    return totalWritten;
+}
+
+#if LIBCURL_VERSION_NUM >= 0x074000  /* curl 7.64.0+ */
+
+/**
+ * Trailing headers callback for libcurl
+ *
+ * This callback is invoked by libcurl to retrieve trailing headers after
+ * all body content has been sent. It appends headers to the curl_slist.
+ *
+ * @param list Pointer to curl_slist pointer to append headers to
+ * @param userdata Pointer to ChunkedRequestState
+ *
+ * @return CURL_TRAILERFUNC_OK (0) on success, CURL_TRAILERFUNC_ABORT (1) on error
+ */
+static int trailing_headers_callback(struct curl_slist **list, void *userdata)
+{
+    ChunkedRequestState *state = (ChunkedRequestState *)userdata;
+
+    if (!state || !list) {
+        return 1; /* CURL_TRAILERFUNC_ABORT */
+    }
+
+    if (!state->trailingHeadersGenerated || state->trailingHeadersCount <= 0) {
+        return 0; /* CURL_TRAILERFUNC_OK - no headers */
+    }
+
+    /* Append each trailing header to the list */
+    for (int i = 0; i < state->trailingHeadersCount; i++) {
+        const char *name = state->trailingHeaders[i].name;
+        const char *value = state->trailingHeaders[i].value;
+
+        if (!name || !value) {
+            continue; /* Skip invalid headers */
+        }
+
+        /* Format header as "Name: Value" */
+        char header[512];
+        int written = snprintf(header, sizeof(header), "%s: %s", name, value);
+
+        if (written < 0 || (size_t)written >= sizeof(header)) {
+            return 1; /* CURL_TRAILERFUNC_ABORT */
+        }
+
+        /* Append to curl's list */
+        struct curl_slist *new_list = curl_slist_append(*list, header);
+        if (!new_list) {
+            return 1; /* CURL_TRAILERFUNC_ABORT */
+        }
+        *list = new_list;
+    }
+
+    return 0; /* CURL_TRAILERFUNC_OK */
+}
+
+/**
+ * Setup curl handle for trailing headers (DISABLED - using manual formatting)
+ *
+ * NOTE: We manually format trailing headers in the data stream now,
+ * so we DON'T use CURLOPT_TRAILERFUNCTION anymore.
+ *
+ * @param curl CURL handle
+ * @param state Chunked request state
+ *
+ * @return S3StatusOK on success, error code otherwise
+ */
+static S3Status setup_trailing_headers(CURL *curl, ChunkedRequestState *state)
+{
+    (void)curl;
+    (void)state;
+    /* DISABLED: We manually format trailers in the chunked_read_callback now */
+    return S3StatusOK;
+}
+
+#else /* curl < 7.64.0 */
+
+static S3Status setup_trailing_headers(CURL *curl, ChunkedRequestState *state)
+{
+    if (state && state->trailingHeadersCallback) {
+        /* Trailing headers not supported in this curl version */
+        return S3StatusTrailingHeadersError;
+    }
+    return S3StatusOK;
+}
+
+#endif /* LIBCURL_VERSION_NUM */
+
+/**
+ * Set signature information for trailer signing
+ *
+ * This must be called from request.c after computing the request signature
+ * to enable x-amz-trailer-signature calculation.
+ *
+ * @param state Chunked request state
+ * @param seedSignature Hex signature from Authorization header
+ * @param timestamp Request timestamp (ISO8601 format)
+ * @param credentialScope Credential scope (date/region/service/aws4_request)
+ * @param signingKey AWS4 signing key (32 bytes)
+ *
+ * @return S3StatusOK on success, error otherwise
+ */
+S3Status chunked_set_signature_info(ChunkedRequestState *state,
+                                   const char *seedSignature,
+                                   const char *timestamp,
+                                   const char *credentialScope,
+                                   const unsigned char *signingKey)
+{
+    if (!state || !seedSignature || !timestamp || !credentialScope || !signingKey) {
+        return S3StatusInternalError;
+    }
+
+    /* Copy signature info */
+    strncpy(state->seedSignature, seedSignature, sizeof(state->seedSignature) - 1);
+    state->seedSignature[sizeof(state->seedSignature) - 1] = '\0';
+
+    strncpy(state->requestDateISO8601, timestamp, sizeof(state->requestDateISO8601) - 1);
+    state->requestDateISO8601[sizeof(state->requestDateISO8601) - 1] = '\0';
+
+    strncpy(state->credentialScope, credentialScope, sizeof(state->credentialScope) - 1);
+    state->credentialScope[sizeof(state->credentialScope) - 1] = '\0';
+
+    memcpy(state->signingKey, signingKey, S3_SHA256_DIGEST_LENGTH);
+
+    state->hasSignatureInfo = 1;
+
+    return S3StatusOK;
+}
+
+/**
+ * Setup curl handle for chunked transfer encoding
+ *
+ * Configures libcurl for chunked encoding and sets up the necessary callbacks.
+ *
+ * @param curl CURL handle
+ * @param state Chunked request state
+ *
+ * @return S3StatusOK on success, error code otherwise
+ */
+S3Status request_setup_chunked_encoding(CURL *curl, ChunkedRequestState *state)
+{
+    CURLcode code;
+
+    if (!curl || !state) {
+        return S3StatusInternalError;
+    }
+
+    /* Enable UPLOAD mode to use PUT method with read callback
+     * Our read callback will provide MANUALLY formatted AWS chunks
+     * (not curl's automatic chunking)
+     */
+    code = curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    if (code != CURLE_OK) {
+        return S3StatusFailedToInitializeRequest;
+    }
+
+    /* Set read callback for providing MANUALLY formatted chunked data */
+    code = curl_easy_setopt(curl, CURLOPT_READFUNCTION, chunked_read_callback);
+    if (code != CURLE_OK) {
+        return S3StatusFailedToInitializeRequest;
+    }
+
+    code = curl_easy_setopt(curl, CURLOPT_READDATA, state);
+    if (code != CURLE_OK) {
+        return S3StatusFailedToInitializeRequest;
+    }
+
+    /* DON'T set CURLOPT_INFILESIZE_LARGE - we'll send manually chunked data
+     * The Transfer-Encoding: chunked header is already set in request.c
+     * Our callback formats data as: <size-hex>\r\n<data>\r\n...0\r\n<trailers>\r\n\r\n
+     */
+
+    /* Setup trailing headers (currently disabled for manual format) */
+    S3Status status = setup_trailing_headers(curl, state);
+    if (status != S3StatusOK) {
+        return status;
+    }
+
+    return S3StatusOK;
+}
+
+/**
+ * Create and initialize a chunked request state
+ *
+ * Public API function to create a chunked request state structure.
+ *
+ * @param statePtr Pointer to receive allocated state structure
+ * @param chunkedCallback Callback for retrieving chunk data
+ * @param trailingCallback Optional callback for trailing headers (may be NULL)
+ * @param callbackData User data passed to callbacks
+ *
+ * @return S3StatusOK on success, error code otherwise
+ */
+S3Status S3_create_chunked_request_state(ChunkedRequestState **statePtr,
+                                        S3ChunkedDataCallback chunkedCallback,
+                                        S3TrailingHeadersCallback trailingCallback,
+                                        void *callbackData)
+{
+    ChunkedRequestState *state;
+    S3Status status;
+
+    if (!statePtr || !chunkedCallback) {
+        return S3StatusInvalidChunkCallback;
+    }
+
+    state = (ChunkedRequestState *)malloc(sizeof(ChunkedRequestState));
+    if (!state) {
+        return S3StatusOutOfMemory;
+    }
+
+    status = chunked_state_initialize(state, chunkedCallback, trailingCallback,
+                                     callbackData, DEFAULT_CHUNK_BUFFER_SIZE);
+
+    if (status != S3StatusOK) {
+        free(state);
+        return status;
+    }
+
+    *statePtr = state;
+    return S3StatusOK;
+}
+
+/**
+ * Destroy a chunked request state
+ *
+ * Public API function to cleanup and free a chunked request state structure.
+ *
+ * @param state State structure to destroy
+ */
+void S3_destroy_chunked_request_state(ChunkedRequestState *state)
+{
+    if (!state) {
+        return;
+    }
+
+    chunked_state_cleanup(state);
+    free(state);
+}
+
+/**
+ * Get total bytes sent in chunked request
+ *
+ * @param state Chunked request state
+ *
+ * @return Total bytes sent, or 0 if state is invalid
+ */
+uint64_t S3_get_chunked_bytes_sent(const ChunkedRequestState *state)
+{
+    return state ? state->totalBytesSent : 0;
+}
+
+/**
+ * Check if chunked request encountered an error
+ *
+ * @param state Chunked request state
+ *
+ * @return 1 if error occurred, 0 otherwise
+ */
+int S3_chunked_request_has_error(const ChunkedRequestState *state)
+{
+    return state ? state->errorOccurred : 1;
+}

--- a/libs3/src/service.c
+++ b/libs3/src/service.c
@@ -177,7 +177,8 @@ void S3_list_service(S3Protocol protocol,
 		&completeCallback,   // completeCallback
 		data,                // callbackData
 		timeoutMs,           // timeoutMs
-		0                    // xAmzObjectAttributes
+		0,                   // xAmzObjectAttributes
+		0                    // chunkedState
 	};
 
 	// Perform the request

--- a/libs3/src/service_access_logging.c
+++ b/libs3/src/service_access_logging.c
@@ -350,7 +350,8 @@ void S3_get_server_access_logging(const S3BucketContext* bucketContext,
 		&getBlsCompleteCallback,         // completeCallback
 		gsData,                          // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request
@@ -549,7 +550,8 @@ void S3_set_server_access_logging(const S3BucketContext* bucketContext,
 		&setSalCompleteCallback,         // completeCallback
 		data,                            // callbackData
 		timeoutMs,                       // timeoutMs
-		0                                // xAmzObjectAttributes
+		0,                               // xAmzObjectAttributes
+		0                                // chunkedState
 	};
 
 	// Perform the request

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -118,6 +118,11 @@ class Test_S3_NoCache_Base(session.make_sessions_mixin([('otherrods', 'rods')], 
         self.s3_context += ';S3_ENABLE_MPU=' + str(self.s3EnableMPU)
         self.s3_context += ';S3_CACHE_DIR=/var/lib/irods'
 
+        if hasattr(self, 's3EnableTrailingChecksumOnUpload'):
+            self.s3_context += ';ENABLE_TRAILING_CHECKSUM_ON_UPLOAD=' + str(self.s3EnableTrailingChecksumOnUpload)
+        if hasattr(self, 's3EnableDirectChecksumRead'):
+            self.s3_context += ';ENABLE_DIRECT_CHECKSUM_READ=' + str(self.s3EnableDirectChecksumRead)
+
         if hasattr(self, 's3DisableCopyObject'):
             self.s3DisableCopyObject = self.s3DisableCopyObject
             self.s3_context += ';S3_ENABLE_COPYOBJECT=0'

--- a/packaging/test_irods_resource_plugin_s3.py
+++ b/packaging/test_irods_resource_plugin_s3.py
@@ -29,6 +29,7 @@ from ..configuration import IrodsConfig
 from .resource_suite import ResourceSuite
 from .test_chunkydevtest import ChunkyDevTest
 
+IRODS_SUPPORTS_CRC64NVME = IrodsConfig().version_tuple > (5, 0, 2)
 
 class Test_Compound_With_S3_Resource(Test_S3_Cache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -176,3 +177,18 @@ class Test_S3_Cache_Glacier(Test_S3_Cache_Glacier_Base, unittest.TestCase):
         self.s3EnableMPU=1
         self.s3stsdate=''
         super(Test_S3_Cache_Glacier, self).__init__(*args, **kwargs)
+
+@unittest.skipUnless(IRODS_SUPPORTS_CRC64NVME, 'iRODS server must support CRC64NVME')
+class Test_S3_NoCache_Trailing_Checksum(Test_S3_NoCache_Base, unittest.TestCase):
+    '''
+    Tests S3 uploads with trailing checksums enabled (CRC64/NVME).
+    '''
+    def __init__(self, *args, **kwargs):
+        """Set up the test."""
+        self.keypairfile='/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'
+        self.s3region='us-east-1'
+        self.s3endPoint='s3.amazonaws.com'
+        self.s3EnableMPU=1
+        self.s3EnableTrailingChecksumOnUpload=1
+        self.s3EnableDirectChecksumRead=1
+        super(Test_S3_NoCache_Trailing_Checksum, self).__init__(*args, **kwargs)

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -7,6 +7,10 @@ import psutil
 import sys
 import unittest
 
+from ..configuration import IrodsConfig
+
+IRODS_SUPPORTS_CRC64NVME = IrodsConfig().version_tuple > (5, 0, 2)
+
 class Test_Compound_With_S3_Resource(Test_S3_Cache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         """Set up the test."""
@@ -107,3 +111,19 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3endPoint='localhost:9001'
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
+
+@unittest.skipUnless(IRODS_SUPPORTS_CRC64NVME, 'iRODS server must support CRC64NVME')
+class Test_S3_NoCache_Trailing_Checksum(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCase):
+    '''
+    Tests S3 uploads with trailing checksums enabled (CRC64/NVME).
+    '''
+    def __init__(self, *args, **kwargs):
+        """Set up the test."""
+        self.proto = 'HTTP'
+        self.keypairfile='/var/lib/irods/minio.keypair'
+        self.s3region='us-east-1'
+        self.s3endPoint = 'localhost:9000'
+        self.s3EnableMPU=1
+        self.s3EnableTrailingChecksumOnUpload=1
+        self.s3EnableDirectChecksumRead=1
+        super(Test_S3_NoCache_Trailing_Checksum, self).__init__(*args, **kwargs)

--- a/packaging/test_irods_resource_plugin_s3_minio.py
+++ b/packaging/test_irods_resource_plugin_s3_minio.py
@@ -4,12 +4,39 @@ from .resource_suite_s3_nocache import Test_S3_NoCache_MPU_Disabled_Base
 from .resource_suite_s3_cache import Test_S3_Cache_Base
 
 import psutil
+import re
+import shutil
+import subprocess
 import sys
 import unittest
 
 from ..configuration import IrodsConfig
 
 IRODS_SUPPORTS_CRC64NVME = IrodsConfig().version_tuple > (5, 0, 2)
+
+MINIO_TRAILING_CHECKSUM_MIN_VERSION = 'RELEASE.2023-01-20T02-05-44Z'
+
+def _get_minio_version():
+    """Get the MinIO server version by running the minio binary.
+
+    Searches for the minio binary in PATH first, then falls back to /minio
+    (used when the binary is downloaded directly rather than installed as a package).
+
+    Returns a tuple of (version_string_or_None, error_string_or_None).
+    """
+    minio_path = shutil.which('minio') or '/minio'
+    try:
+        result = subprocess.run(
+            [minio_path, '--version'],
+            capture_output=True, text=True, timeout=5
+        )
+        match = re.search(r'RELEASE\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z',
+                          result.stdout + result.stderr)
+        if match:
+            return match.group(), None
+        return None, f'No version found in output: [{result.stdout + result.stderr}]'
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        return None, f'Failed to run [{minio_path}]: {e}'
 
 class Test_Compound_With_S3_Resource(Test_S3_Cache_Base, unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -112,7 +139,9 @@ class Test_S3_NoCache_EU_Central_1(Test_S3_NoCache_Base, unittest.TestCase):
         self.s3EnableMPU=1
         super(Test_S3_NoCache_EU_Central_1, self).__init__(*args, **kwargs)
 
+_minio_version, _minio_version_error = _get_minio_version()
 @unittest.skipUnless(IRODS_SUPPORTS_CRC64NVME, 'iRODS server must support CRC64NVME')
+@unittest.skipUnless(_minio_version is not None and _minio_version >= MINIO_TRAILING_CHECKSUM_MIN_VERSION, f'MinIO version must be >= {MINIO_TRAILING_CHECKSUM_MIN_VERSION} to support trailing checksums.  Current MinIO version is {_minio_version}.  Error: {_minio_version_error}.')
 class Test_S3_NoCache_Trailing_Checksum(Test_S3_NoCache_Large_File_Tests_Base, unittest.TestCase):
     '''
     Tests S3 uploads with trailing checksums enabled (CRC64/NVME).

--- a/s3_resource/include/irods/private/s3_resource/s3_resource.hpp
+++ b/s3_resource/include/irods/private/s3_resource/s3_resource.hpp
@@ -71,6 +71,7 @@ unsigned int s3_get_restoration_days(irods::plugin_property_map& _prop_map);
 std::string s3_get_restoration_tier(irods::plugin_property_map& _prop_map);
 std::string s3_get_storage_class_from_configuration(irods::plugin_property_map& _prop_map);
 bool s3_direct_checksum_read_enabled(irods::plugin_property_map& _prop_map);
+bool s3_trailing_checksum_on_upload_enabled(irods::plugin_property_map& _prop_map);
 
 void StoreAndLogStatus(S3Status status, const S3ErrorDetails *error,
         const char *function, const S3BucketContext *pCtx, S3Status *pStatus,

--- a/s3_resource/src/s3_operations.cpp
+++ b/s3_resource/src/s3_operations.cpp
@@ -690,6 +690,7 @@ namespace irods_s3 {
         s3_config.max_single_part_upload_size = s3GetMaxUploadSizeMB(_ctx.prop_map()) * 1024 * 1024;
         s3_config.non_data_transfer_timeout_seconds = get_non_data_transfer_timeout_seconds(_ctx.prop_map());
         s3_config.s3_storage_class = s3_get_storage_class_from_configuration(_ctx.prop_map());
+        s3_config.trailing_checksum_on_upload_enabled = s3_trailing_checksum_on_upload_enabled(_ctx.prop_map());
 
         auto sts_date_setting = s3GetSTSDate(_ctx.prop_map());
         s3_config.s3_sts_date_str = sts_date_setting == S3STSAmzOnly ? "amz" : sts_date_setting == S3STSAmzAndDate ? "both" : "date";
@@ -2557,13 +2558,15 @@ namespace irods_s3 {
                 );
 
 		logger::debug("{}:{} ({}) checksum_crc64_nvme = [{}] checksum_sha1 = [{}] "
-                "checksum_sha256 = [{}] checksum_type = [{}]",
+                "checksum_sha256 = [{}] checksum_crc32 = [{}] checksum_crc32c = [{}] checksum_type = [{}]",
                 __FILE__,
                 __LINE__,
                 __func__,
                 get_object_attributes_data.checksum_crc64_nvme,
                 get_object_attributes_data.checksum_sha1,
                 get_object_attributes_data.checksum_sha256,
+                get_object_attributes_data.checksum_crc32,
+                get_object_attributes_data.checksum_crc32c,
                 get_object_attributes_data.checksum_type);
 
 

--- a/s3_resource/src/s3_resource.cpp
+++ b/s3_resource/src/s3_resource.cpp
@@ -32,6 +32,7 @@
 #include <irods/irods_virtual_path.hpp>
 #include <irods/irods_resource_backport.hpp>
 #include <irods/irods_query.hpp>
+#include <irods/library_features.h>
 
 // =-=-=-=-=-=-=-
 // stl includes
@@ -153,6 +154,7 @@ const std::string  s3_restoration_tier{"S3_RESTORATION_TIER"};          //  eith
 const std::string  s3_enable_copyobject{"S3_ENABLE_COPYOBJECT"};       //  If set to 0 the CopyObject API will not be used.  Default is to use CopyObject.
 const std::string  s3_non_data_transfer_timeout_seconds{"S3_NON_DATA_TRANSFER_TIMEOUT_SECONDS"};
 const std::string  enable_direct_checksum_read("ENABLE_DIRECT_CHECKSUM_READ");
+const std::string  enable_trailing_checksum_on_upload("ENABLE_TRAILING_CHECKSUM_ON_UPLOAD");
 
 const std::string  s3_number_of_threads{"S3_NUMBER_OF_THREADS"};        //  to save number of threads
 const std::size_t  S3_DEFAULT_RETRY_WAIT_SECONDS = 2;
@@ -1245,6 +1247,35 @@ bool s3_direct_checksum_read_enabled(
 	return enable_flag;
 } // end s3_direct_checksum_read_enabled
 
+// enable_trailing_checksum_on_upload - default is false
+bool s3_trailing_checksum_on_upload_enabled(
+		irods::plugin_property_map& _prop_map )
+{
+	std::string enable_str;
+	bool enable_flag = false;
+
+	irods::error ret = _prop_map.get< std::string >(
+			enable_trailing_checksum_on_upload,
+			enable_str );
+	if (ret.ok()) {
+		// Only 0 = no, 1 = yes.
+		std::string resource_name = get_resource_name(_prop_map);
+		if ("0" != enable_str && "1" != enable_str) {
+			s3_logger::warn("[resource_name={}] Invalid value for {} of {}. The value should be 0 or 1. Defaulting to 0.",
+					resource_name, enable_trailing_checksum_on_upload, enable_str);
+		}
+		else if ("1" == enable_str) {
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+			enable_flag = true;
+#else
+			s3_logger::warn("[resource_name={}] {} flag set to 1 but this version of iRODS does not support CRC64/NVME.  This feature is disabled.",
+					resource_name, enable_trailing_checksum_on_upload);
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+		}
+	}
+	return enable_flag;
+} // end enable_trailing_checksum_on_upload
+
 irods::error s3GetFile(
     const std::string& _filename,
     const std::string& _s3ObjName,
@@ -2011,7 +2042,7 @@ irods::error s3PutCopyFile(
                 std::string&& hostname = s3GetHostname(_prop_map);
                 bucketContext.hostName = hostname.c_str(); // Safe to do, this is a local copy of the data structure
                 manager.pCtx = &bucketContext;
-                S3_complete_multipart_upload(&bucketContext, key.c_str(), &commit_handler, manager.upload_id, manager.remaining, NULL, 0, &manager);
+                S3_complete_multipart_upload(&bucketContext, key.c_str(), &commit_handler, manager.upload_id, manager.remaining, nullptr, nullptr, 0, &manager);
                 if (manager.status != S3StatusOK) {
                     s3_sleep( retry_wait );
                     retry_wait *= 2;

--- a/s3_transport/include/irods/private/s3_transport/callbacks.hpp
+++ b/s3_transport/include/irods/private/s3_transport/callbacks.hpp
@@ -35,6 +35,13 @@
 #include "irods/private/s3_transport/multipart_shared_data.hpp"
 #include "irods/private/s3_transport/types.hpp"
 #include "irods/private/s3_transport/logging_category.hpp"
+#include "irods/irods_hasher_factory.hpp"
+
+// iRODS includes
+#include <irods/library_features.h>
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+    #include <irods/CRC64NVMEStrategy.hpp>
+#endif
 
 namespace irods::experimental::io::s3_transport
 {
@@ -57,6 +64,7 @@ namespace irods::experimental::io::s3_transport
                 , shmem_key{}
                 , shared_memory_timeout_in_seconds{constants::DEFAULT_SHARED_MEMORY_TIMEOUT_IN_SECONDS}
                 , callback_counter{0}
+                , status{libs3_types::status_ok}
             {}
 
             virtual libs3_types::status callback_implementation(int libs3_buffer_size,
@@ -140,7 +148,7 @@ namespace irods::experimental::io::s3_transport
 
                 if (!cache_fstream) {
                     logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                            __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                            __FILE__, __LINE__, __func__, this->thread_identifier);
                     return S3StatusAbortedByCallback;
                 }
 
@@ -171,7 +179,7 @@ namespace irods::experimental::io::s3_transport
                 cache_fstream.open(filename.c_str(), std::ios_base::out);
                 if (!cache_fstream) {
                     logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                            __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                            __FILE__, __LINE__, __func__, this->thread_identifier);
                 }
             }
 
@@ -254,7 +262,8 @@ namespace irods::experimental::io::s3_transport
 
                 callback_for_write_to_s3_base(libs3_types::bucket_context& _saved_bucket_context,
                                               upload_manager& _manager)
-                    : enable_md5{false}
+                    : status{libs3_types::status_ok}
+                    , enable_md5{false}
                     , thread_identifier{0}
                     , object_key{}
                     , shmem_key{}
@@ -266,7 +275,13 @@ namespace irods::experimental::io::s3_transport
                     , callback_counter{0}
                     , offset{0}
                     , transport_object_ptr{nullptr}
-                {}
+                    , calculate_crc64_nvme{false}
+                    , trailing_checksum_value{}
+                {
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                    irods::getHasher(irods::CRC64NVME_NAME.data(), hasher);
+#endif
+                }
 
 
                 virtual int callback_implementation(int libs3_buffer_size,
@@ -342,7 +357,9 @@ namespace irods::experimental::io::s3_transport
                 int                          callback_counter;
                 std::int64_t                 offset;       /* For multiple upload */
                 s3_transport<CharT>*         transport_object_ptr;
-
+                bool                         calculate_crc64_nvme;
+                std::string                  trailing_checksum_value;  // Stores checksum for trailing headers callback
+                irods::Hasher                hasher;
         };
 
         template <typename CharT>
@@ -368,7 +385,7 @@ namespace irods::experimental::io::s3_transport
 
                     if (!cache_fstream) {
                         logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                         return S3StatusAbortedByCallback;
                     }
 
@@ -385,6 +402,11 @@ namespace irods::experimental::io::s3_transport
                     if (bytes_read_from_cache > 0) {
                         this->offset += bytes_read_from_cache;
                         this->bytes_written += bytes_read_from_cache;
+
+                        // Update hasher for trailing checksum calculation
+                        if (this->calculate_crc64_nvme) {
+                            this->hasher.update(std::string(libs3_buffer, bytes_read_from_cache));
+                        }
                     }
 
                     return bytes_read_from_cache;
@@ -405,7 +427,7 @@ namespace irods::experimental::io::s3_transport
                     cache_fstream.open(filename.c_str(), std::ios_base::in);
                     if (!cache_fstream) {
                         logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                     }
                 }
 
@@ -466,7 +488,7 @@ namespace irods::experimental::io::s3_transport
                         logger::error("{}:{} ({}) [[{}]] "
                                 "Timed out waiting to read from circular buffer.  "
                                 "Remote likely hung up...",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
 
                         // save that we got a timeout so that we don't keep retrying
 
@@ -486,6 +508,9 @@ namespace irods::experimental::io::s3_transport
                         return 0;
                     }
 
+                    if (this->calculate_crc64_nvme) {
+                        this->hasher.update(std::string(libs3_buffer, bytes_to_return));
+                    }
                     this->bytes_written += bytes_to_return;
 
                     return bytes_to_return;
@@ -501,7 +526,7 @@ namespace irods::experimental::io::s3_transport
                         // this should never happen but catch and log just in case
                         logger::error("{}:{} ({}) [[{}]] "
                                 "Unexpected timeout when removing entries from circular buffer.",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                     }
                 }
 
@@ -551,16 +576,16 @@ namespace irods::experimental::io::s3_transport
         class callback_for_write_to_s3_base
         {
 
-
             public:
 
                 callback_for_write_to_s3_base(libs3_types::bucket_context& _saved_bucket_context,
                                               upload_manager& _manager)
-                    : enable_md5{false}
+                    : status{libs3_types::status_ok}
+                    , enable_md5{false}
                     , thread_identifier{0}
-                    , shared_memory_timeout_in_seconds{constants::DEFAULT_SHARED_MEMORY_TIMEOUT_IN_SECONDS}
                     , object_key{}
                     , shmem_key{}
+                    , shared_memory_timeout_in_seconds{constants::DEFAULT_SHARED_MEMORY_TIMEOUT_IN_SECONDS}
                     , sequence{0}
                     , content_length{0}
                     , saved_bucket_context{_saved_bucket_context}
@@ -569,7 +594,13 @@ namespace irods::experimental::io::s3_transport
                     , callback_counter{0}
                     , offset{0}
                     , transport_object_ptr{nullptr}
-                {}
+                    , calculate_crc64_nvme{false}
+                    , trailing_checksum_value{}
+                {
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                    irods::getHasher(irods::CRC64NVME_NAME.data(), hasher);
+#endif
+                }
 
 
                 virtual int callback_implementation(int libs3_buffer_size,
@@ -634,7 +665,7 @@ namespace irods::experimental::io::s3_transport
                             }
 
                         } catch (const bi::bad_alloc& ba) {
-                            logger::error("{}:{} ({}) Exception caught allocating room for etags string. [{}]", __FILE__, __LINE__, __FUNCTION__, ba.what());
+                            logger::error("{}:{} ({}) Exception caught allocating room for etags string. [{}]", __FILE__, __LINE__, __func__, ba.what());
                             return S3StatusOutOfMemory;
                         }
                         return libs3_types::status_ok;
@@ -667,9 +698,9 @@ namespace irods::experimental::io::s3_transport
                 libs3_types::status          status;
                 bool                         enable_md5;
                 std::uint64_t                thread_identifier;
-                time_t                       shared_memory_timeout_in_seconds;
                 std::string                  object_key;
                 std::string                  shmem_key;
+                time_t                       shared_memory_timeout_in_seconds;
 
                 std::uint64_t                sequence;
                 std::int64_t                 content_length;
@@ -685,6 +716,9 @@ namespace irods::experimental::io::s3_transport
                 int                          callback_counter;
                 std::int64_t                 offset;
                 s3_transport<CharT>*         transport_object_ptr;
+                bool                         calculate_crc64_nvme;
+                std::string                  trailing_checksum_value;  // Stores checksum for trailing headers callback
+                irods::Hasher                hasher;
 
         };
 
@@ -711,7 +745,7 @@ namespace irods::experimental::io::s3_transport
 
                     if (!cache_fstream) {
                         logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                         return 0;
                     }
 
@@ -728,6 +762,11 @@ namespace irods::experimental::io::s3_transport
                     if (bytes_read_from_cache > 0) {
                         this->offset += bytes_read_from_cache;
                         this->bytes_written += bytes_read_from_cache;
+
+                        // Update hasher for trailing checksum calculation
+                        if (this->calculate_crc64_nvme) {
+                            this->hasher.update(std::string(libs3_buffer, bytes_read_from_cache));
+                        }
                     }
 
 
@@ -747,7 +786,7 @@ namespace irods::experimental::io::s3_transport
                     cache_fstream.open(filename.c_str(), std::ios_base::in);
                     if (!cache_fstream) {
                         logger::error("{}:{} ({}) [[{}]] could not open cache file",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                     }
                 }
 
@@ -806,7 +845,7 @@ namespace irods::experimental::io::s3_transport
                     } catch(const std::system_error& se)  {
                         logger::error("{}:{} ({}) [[{}]] "
                                 "System error when peaking into circular buffer.  {}",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier, se.what());
+                                __FILE__, __LINE__, __func__, this->thread_identifier, se.what());
                         return 0;
                     } catch (timeout_exception& e) {
 
@@ -815,7 +854,7 @@ namespace irods::experimental::io::s3_transport
                         logger::error("{}:{} ({}) [[{}]] "
                                 "Timed out waiting to read from circular buffer.  "
                                 "Remote likely hung up...",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
 
                         // save that we got a timeout so that we don't keep retrying
                         auto shmem_key =  this->shmem_key;
@@ -835,6 +874,9 @@ namespace irods::experimental::io::s3_transport
 
                     }
 
+                    if (this->calculate_crc64_nvme) {
+                        this->hasher.update(std::string(libs3_buffer, bytes_to_return));
+                    }
                     this->bytes_written += bytes_to_return;
 
                     return bytes_to_return;
@@ -850,7 +892,7 @@ namespace irods::experimental::io::s3_transport
                         // this should never happen but catch and log just in case
                         logger::error("{}:{} ({}) [[{}]] "
                                 "Unexpected timeout when removing entries from circular buffer.",
-                                __FILE__, __LINE__, __FUNCTION__, this->thread_identifier);
+                                __FILE__, __LINE__, __func__, this->thread_identifier);
                     }
                 }
 

--- a/s3_transport/include/irods/private/s3_transport/multipart_shared_data.hpp
+++ b/s3_transport/include/irods/private/s3_transport/multipart_shared_data.hpp
@@ -19,6 +19,8 @@
 
 #include <fmt/format.h>
 
+#include <cstdint>
+
 namespace irods::experimental::io::s3_transport::shared_data
 {
 
@@ -30,13 +32,13 @@ namespace irods::experimental::io::s3_transport::shared_data
         using segment_manager       = bi::managed_shared_memory::segment_manager;
         using void_allocator        = boost::container::scoped_allocator_adaptor
                                       <bi::allocator<void, segment_manager> >;
-        using int_allocator         = bi::allocator<int, segment_manager>;
+        using uint64_t_allocator    = bi::allocator<uint64_t, segment_manager>;
         using char_allocator        = bi::allocator<char, segment_manager>;
-        using shm_int_vector        = bi::vector<int, int_allocator>;
         using shm_char_string       = bi::basic_string<char, std::char_traits<char>,
                                       char_allocator>;
         using char_string_allocator = bi::allocator<shm_char_string, segment_manager>;
         using shm_string_vector     = bi::vector<shm_char_string, char_string_allocator>;
+		using uint64_t_vector       = bi::vector<uint64_t, uint64_t_allocator>;
     }
 
     // data that needs to be shared among different processes
@@ -58,6 +60,8 @@ namespace irods::experimental::io::s3_transport::shared_data
             , file_open_counter{0}
             , cache_file_flushed{false}
             , know_number_of_threads{true}
+            , checksum_vector{allocator}
+			, part_size_vector{allocator}
             , first_open_has_trunc_flag{false}
         {}
 
@@ -79,6 +83,8 @@ namespace irods::experimental::io::s3_transport::shared_data
         int                                   file_open_counter;
         bool                                  cache_file_flushed;
         bool                                  know_number_of_threads;
+        interprocess_types::uint64_t_vector   checksum_vector;
+        interprocess_types::uint64_t_vector   part_size_vector;
 
         // this is set so that multiple processes that are used to write to the file don't download the file
         // to cache if the trunc flag is not set.

--- a/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
+++ b/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
@@ -4,15 +4,22 @@
 #include "irods/private/s3_transport/circular_buffer.hpp"
 
 // iRODS includes
+#include <irods/library_features.h>
 #include <irods/transport/transport.hpp>
 #include <irods/thread_pool.hpp>
 #include <irods/rcMisc.h>
 #include <irods/rodsErrorTable.h>
 #include <irods/irods_error.hpp>
+#include <irods/base64.hpp>
+
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+    #include <irods/CRC64NVMEStrategy.hpp>
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
 
 // misc includes
 #include <nlohmann/json.hpp>
 #include "libs3/libs3.h"
+#include "libs3/libs3_chunked.h"
 
 // stdlib and misc includes
 #include <string>
@@ -134,7 +141,7 @@ namespace irods::experimental::io::s3_transport
             , max_single_part_upload_size{DEFAULT_MAX_SINGLE_PART_UPLOAD_SIZE}
             , non_data_transfer_timeout_seconds{S3_DEFAULT_NON_DATA_TRANSFER_TIMEOUT_SECONDS}
             , s3_storage_class{S3_DEFAULT_STORAGE_CLASS}
-
+            , trailing_checksum_on_upload_enabled{false}
         {}
 
         std::int64_t object_size;
@@ -183,6 +190,7 @@ namespace irods::experimental::io::s3_transport
         std::int64_t max_single_part_upload_size;
         unsigned int non_data_transfer_timeout_seconds;
         std::string  s3_storage_class;
+        bool         trailing_checksum_on_upload_enabled;
     };
 
 
@@ -385,7 +393,7 @@ namespace irods::experimental::io::s3_transport
 
         bool close(const on_close_success* _on_close_success = nullptr) override
         {
-            logger::debug("{}:{} ({}) [[{}]] fd_={}, is_open={} use_cache_={}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), fd_, is_open(), use_cache_);
+            logger::debug("{}:{} ({}) [[{}]] fd_={}, is_open={} use_cache_={}", __FILE__, __LINE__, __func__, get_thread_identifier(), fd_, is_open(), use_cache_);
 
             namespace bi = boost::interprocess;
             namespace types = shared_data::interprocess_types;
@@ -432,14 +440,14 @@ namespace irods::experimental::io::s3_transport
                 }
 
                 logger::debug("{}:{} ({}) [[{}]] close BEFORE decrement file_open_counter = {}",
-                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), data.file_open_counter);
+                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), data.file_open_counter);
 
                 if (data.file_open_counter > 0) {
                     data.file_open_counter -= 1;
                 }
 
                 logger::debug("{}:{} ({}) [[{}]] close AFTER decrement file_open_counter = {}",
-                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), data.file_open_counter);
+                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), data.file_open_counter);
 
                 // determine if this is the last file to close
                 // for now on redirect cache is forced and we do not know the # threads
@@ -449,7 +457,7 @@ namespace irods::experimental::io::s3_transport
                     ( !(data.know_number_of_threads) && data.file_open_counter == 0 && !data.cache_file_flushed );
 
                 logger::debug("{}:{} ({}) [[{}]] [last_file_to_close={}][know_number_of_threads={}][threads_remaining_to_close={}]",
-                        __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(),
+                        __FILE__, __LINE__, __func__, this->get_thread_identifier(),
                         last_file_to_close_, data.know_number_of_threads, data.threads_remaining_to_close);
 
                 // if a critical error occurred - do not flush cache file or complete multipart upload
@@ -486,7 +494,7 @@ namespace irods::experimental::io::s3_transport
                     // not last file to close and using cache - close cache stream
                     if (use_cache_) {
                         logger::debug("{}:{} ({}) [[{}]] closing cache file",
-                                __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
+                                __FILE__, __LINE__, __func__, this->get_thread_identifier());
                         cache_fstream_.close();
                     }
                 }
@@ -498,13 +506,13 @@ namespace irods::experimental::io::s3_transport
             if (result == additional_processing_enum::DO_FLUSH_CACHE_FILE) {
 
                 logger::debug("{}:{} ({}) [[{}]] closing cache file",
-                        __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
+                        __FILE__, __LINE__, __func__, this->get_thread_identifier());
 
                 cache_fstream_.close();
 
                 if (error_codes::SUCCESS != flush_cache_file(shm_obj)) {
                     logger::error("{}:{} ({}) [[{}]] flush_cache_file returned error",
-                            __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
+                            __FILE__, __LINE__, __func__, this->get_thread_identifier());
                     this->set_error(ERROR(S3_PUT_ERROR, "flush_cache_file returned error"));
                     return_value = false;
                 }
@@ -561,7 +569,7 @@ namespace irods::experimental::io::s3_transport
                     std::streamoff current_position = this->cache_fstream_.tellp();
 
                     const auto msg = fmt::format("send() position={} size={} position_after_write=", position_before_write, _buffer_size, current_position);
-                    logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), msg.c_str());
+                    logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, this->get_thread_identifier(), msg.c_str());
 
                     // return bytes written
                     std::streamsize bytes_written = current_position - position_before_write;
@@ -596,7 +604,7 @@ namespace irods::experimental::io::s3_transport
             // if config_.bytes_this_thread is 0 then bail
             if (config_.number_of_client_transfer_threads > 1 && 0 == get_bytes_this_thread()) {
                 logger::error("{}:{} ({}) [[{}]] part size is zero", __FILE__, __LINE__,
-                        __FUNCTION__, get_thread_identifier());
+                        __func__, get_thread_identifier());
                 this->set_error(ERROR(S3_PUT_ERROR, "Part size was set to zero"));
                 return 0;
             }
@@ -647,24 +655,11 @@ namespace irods::experimental::io::s3_transport
                     logger::error("{}:{} ({}) [[{}]] "
                             "Unexpected timeout when pushing onto circular buffer.  "
                             "Thread writing to S3 may have died.  Returning 0 bytes processed.",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                            __FILE__, __LINE__, __func__, get_thread_identifier());
                     set_error(ERROR(S3_PUT_ERROR, "Unexpected timeout when pushing onto circular buffer."));
                     return 0;
                 }
 
-            }
-
-            try {
-                circular_buffer_.push_back(&_buffer[offset], &_buffer[_buffer_size]);
-            } catch (timeout_exception& e) {
-
-                // timeout trying to push onto circular buffer
-                logger::error("{}:{} ({}) [[{}]] "
-                        "Unexpected timeout when pushing onto circular buffer.  "
-                        "Thread writing to S3 may have died.  Returning 0 bytes processed.",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
-                set_error(ERROR(S3_PUT_ERROR, "Unexpected timeout when pushing onto circular buffer."));
-                return 0;
             }
 
             return _buffer_size;
@@ -704,7 +699,7 @@ namespace irods::experimental::io::s3_transport
                             irods::error ret = get_object_s3_status(object_key_, bucket_context_, existing_object_size, object_status, storage_class);
                             if (!ret.ok() || object_status == object_s3_status::DOES_NOT_EXIST) {
                                 logger::error("{}:{} ({}) [[{}]] seek failed because object size is unknown and HEAD failed",
-                                         __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                                         __FILE__, __LINE__, __func__, get_thread_identifier());
                                 return seek_error;
                             }
                         }
@@ -887,7 +882,7 @@ namespace irods::experimental::io::s3_transport
             std::fstream fs(cache_file_path_);
             if (!fs || !fs.is_open()) {
                 logger::error("{}:{} ({}) [[{}]] could not open cache file to get size",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                        __FILE__, __LINE__, __func__, get_thread_identifier());
                 return 0;
             }
 
@@ -912,7 +907,7 @@ namespace irods::experimental::io::s3_transport
 
                 if (error_codes::SUCCESS != ret) {
                     logger::error("{}:{} ({}) [[{}]] open returning false [last_error_code={}]",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), static_cast<int>(ret));
+                            __FILE__, __LINE__, __func__, get_thread_identifier(), static_cast<int>(ret));
 
                     // update the last error
                     shm_obj.atomic_exec([ret](auto& data) {
@@ -925,7 +920,7 @@ namespace irods::experimental::io::s3_transport
             } else {
                 if (error_codes::SUCCESS != last_error_code) {
                     logger::error("{}:{} ({}) [[{}]] open returning false [last_error_code={}]",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                            __FILE__, __LINE__, __func__, get_thread_identifier(),
                             static_cast<int>(last_error_code));
                     this->set_error(ERROR(S3_PUT_ERROR, "Initiate multipart failed"));
                     return false;
@@ -940,7 +935,7 @@ namespace irods::experimental::io::s3_transport
                 std::int64_t s3_object_size)
         {
             logger::debug("{}:{} ({}) [[{}]] downloading object to cache\n",
-                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                    __FILE__, __LINE__, __func__, get_thread_identifier());
 
             // shmem is already locked here
 
@@ -952,7 +947,7 @@ namespace irods::experimental::io::s3_transport
                 boost::filesystem::create_directories(parent_path);
             } catch (boost::filesystem::filesystem_error& e) {
                 logger::error("{}:{} ({}) [[{}]] Could not download file to cache.  {}",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), e.what());
+                        __FILE__, __LINE__, __func__, get_thread_identifier(), e.what());
                 return cache_file_download_status::FAILED;
             }
             cache_file_path_ = cache_file.string();
@@ -978,7 +973,7 @@ namespace irods::experimental::io::s3_transport
                 {
 
                     logger::error("{}:{} ({}) [[{}]] Not enough disk space to download object to cache.",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                            __FILE__, __LINE__, __func__, get_thread_identifier());
 
                     return shm_obj.atomic_exec([](auto& data) {
                         return data.cache_file_download_progress = cache_file_download_status::FAILED;
@@ -1027,7 +1022,7 @@ namespace irods::experimental::io::s3_transport
 
                 if (bytes_downloaded != s3_object_size) {
                     logger::error("{}:{} ({}) [[{}]] Failed downloading to cache - bytes_downloaded ({}) != s3_object_size ({}).",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), bytes_downloaded, s3_object_size);
+                            __FILE__, __LINE__, __func__, get_thread_identifier(), bytes_downloaded, s3_object_size);
                     fflush(stderr);
                     return shm_obj.atomic_exec([](auto& data) {
                         return data.cache_file_download_progress = cache_file_download_status::FAILED;
@@ -1051,7 +1046,7 @@ namespace irods::experimental::io::s3_transport
         error_codes flush_cache_file(named_shared_memory_object& shm_obj) {
 
             logger::debug("{}:{} ({}) [[{}]] Flushing cache file.",
-                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                    __FILE__, __LINE__, __func__, get_thread_identifier());
 
             error_codes return_value = error_codes::SUCCESS;
 
@@ -1067,7 +1062,7 @@ namespace irods::experimental::io::s3_transport
             ifs.open(cache_file_path_.c_str(), std::ios::out);
             if (!ifs || !ifs.is_open()) {
                 logger::error("{}:{} ({}) [[{}]] Failed to open cache file.",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                        __FILE__, __LINE__, __func__, get_thread_identifier());
                 return error_codes::UPLOAD_FILE_ERROR;
             }
 
@@ -1076,19 +1071,19 @@ namespace irods::experimental::io::s3_transport
             ifs.close();
 
             logger::debug("{}:{} ({}) [[{}]] cache_file_size is {}",
-                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), cache_file_size);
+                    __FILE__, __LINE__, __func__, get_thread_identifier(), cache_file_size);
             logger::debug("{}:{} ({}) [[{}]] number_of_cache_transfer_threads is {}",
-                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), config_.number_of_cache_transfer_threads);
+                    __FILE__, __LINE__, __func__, get_thread_identifier(), config_.number_of_cache_transfer_threads);
 
             if (config_.number_of_cache_transfer_threads == 0) {
                 logger::error("{}:{} ({}) [[{}]] number_of_cache_transfer_threads set to an invalid value (0).",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                        __FILE__, __LINE__, __func__, get_thread_identifier());
                 return error_codes::UPLOAD_FILE_ERROR;
             }
 
             if (config_.max_single_part_upload_size == 0) {
                 logger::error("{}:{} ({}) [[{}]] max_single_part_upload_size set to an invalid value (0).",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier());
+                        __FILE__, __LINE__, __func__, get_thread_identifier());
                 return error_codes::UPLOAD_FILE_ERROR;
             }
 
@@ -1185,7 +1180,7 @@ namespace irods::experimental::io::s3_transport
                     preferred_part_size >>= 1;
 
                     logger::warn("{}:{} ({}) [[{}]] error in flushing cache file.  Trying a part size of {}.",
-                        __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), preferred_part_size);
+                        __FILE__, __LINE__, __func__, this->get_thread_identifier(), preferred_part_size);
                 } else {
                     break;
                 }
@@ -1193,7 +1188,7 @@ namespace irods::experimental::io::s3_transport
 
             // remove cache file
             logger::debug("{}:{} ({}) [[{}]] removing cache file {}",
-                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), cache_file_path_.c_str());
+                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), cache_file_path_.c_str());
             std::remove(cache_file_path_.c_str());
 
             // set cache file download flag to NOT_STARTED
@@ -1321,7 +1316,7 @@ namespace irods::experimental::io::s3_transport
             logger::debug("{}:{} ({}) [[{}]] [_mode & in = {}][_mode & out = {}]"
                 "[_mode & trunc = {}][_mode & app = {}][_mode & ate = {}]"
                 "[_mode & binary = {}]",
-                __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                __FILE__, __LINE__, __func__, get_thread_identifier(),
                 (_mode & std::ios_base::in) == std::ios_base::in,
                 (_mode & std::ios_base::out) == std::ios_base::out,
                 (_mode & std::ios_base::trunc) == std::ios_base::trunc,
@@ -1358,7 +1353,7 @@ namespace irods::experimental::io::s3_transport
 
             logger::debug("{}:{} ({}) [[{}]] [object_key_ = {}][use_cache_ = {}]"
                 "[download_to_cache_ = {}]",
-                __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                __FILE__, __LINE__, __func__, get_thread_identifier(),
                 object_key_.c_str(),
                 use_cache_,
                 download_to_cache_);
@@ -1402,6 +1397,21 @@ namespace irods::experimental::io::s3_transport
                 // been closed and flushed to S3.
                 const auto m = mode_ & ~(std::ios_base::ate | std::ios_base::binary);
                 if ((std::ios_base::out | std::ios_base::trunc) == m) {
+                    // Only reset multipart state on the FIRST open (file_open_counter == 0).
+                    // Subsequent opens by other threads should not clear state that may have
+                    // already been initialized by the first thread.
+                    if (0 == data.file_open_counter) {
+                        // Reset multipart upload state for new write operation.
+                        // The shared memory may be reused from a previous upload of the same object,
+                        // so we need to clear stale state to ensure a fresh multipart upload is initiated.
+                        data.done_initiate_multipart = false;
+                        data.upload_id.clear();
+                        data.etags.clear();
+                        data.checksum_vector.clear();
+                        data.part_size_vector.clear();
+                        data.last_error_code = error_codes::SUCCESS;
+                        data.circular_buffer_read_timeout = false;
+                    }
                     data.first_open_has_trunc_flag = true;
                 }
                 else if (data.first_open_has_trunc_flag) {
@@ -1414,13 +1424,13 @@ namespace irods::experimental::io::s3_transport
 
                 data.file_open_counter += 1;
                 logger::debug("{}:{} ({}) [[{}]] number_of_client_transfer_threads = {}",
-                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), this->config_.number_of_client_transfer_threads);
+                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), this->config_.number_of_client_transfer_threads);
                 if (this->config_.number_of_client_transfer_threads <= 0) {
                     data.know_number_of_threads = false;
                 }
 
                 logger::debug("{}:{} ({}) [[{}]] open file_open_counter = {}",
-                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), data.file_open_counter);
+                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), data.file_open_counter);
 
                 std::string storage_class;  // used if in archive
 
@@ -1457,7 +1467,7 @@ namespace irods::experimental::io::s3_transport
                 }
 
                 if (object_status == object_s3_status::IN_S3 && this->download_to_cache_) {
-                    logger::debug("{}:{} ({}) [[{}]] Downloading object to cache", __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier());
+                    logger::debug("{}:{} ({}) [[{}]] Downloading object to cache", __FILE__, __LINE__, __func__, this->get_thread_identifier());
 
                     cache_file_download_status download_status = this->download_object_to_cache(shm_obj, s3_object_size);
 
@@ -1481,11 +1491,11 @@ namespace irods::experimental::io::s3_transport
 
                         try {
                             logger::debug("{}:{} ({}) [[{}]] Creating parent_path  {}",
-                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), parent_path.string().c_str());
+                                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), parent_path.string().c_str());
                             boost::filesystem::create_directories(parent_path);
                         } catch (boost::filesystem::filesystem_error& e) {
                             logger::error("{}:{} ({}) [[{}]] Could not create parent directories for cache file.  {}",
-                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), e.what());
+                                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), e.what());
                             return_value = false;
                             return;
                         }
@@ -1512,18 +1522,18 @@ namespace irods::experimental::io::s3_transport
 						// Try opening for read and write. If it fails, create the file then open for read/write.
                         cache_fstream_.open(cache_file_path_.c_str(), mode | std::ios_base::in | std::ios_base::out);
                         if (!cache_fstream_.is_open()) {
-                            logger::debug("{}:{} ({}) [[{}]] opened cache file {} with create [trunc_flag={}]", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
+                            logger::debug("{}:{} ({}) [[{}]] opened cache file {} with create [trunc_flag={}]", __FILE__, __LINE__, __func__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
                             // file may not exist, open with std::ios_base::out to create then with in/out
                             cache_fstream_.open(cache_file_path_.c_str(), std::ios_base::out);
                             cache_fstream_.close();
                             cache_fstream_.open(cache_file_path_.c_str(), mode | std::ios_base::in | std::ios_base::out);
                         } else {
-                            logger::debug("{}:{} ({}) [[{}]] opened cache file {} [trunc_flag={}]", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
+                            logger::debug("{}:{} ({}) [[{}]] opened cache file {} [trunc_flag={}]", __FILE__, __LINE__, __func__, get_thread_identifier(), cache_file_path_.c_str(), trunc_flag);
                         }
 
                         if (!cache_fstream_ || !cache_fstream_.is_open()) {
                             logger::error("{}:{} ({}) [[{}]] Failed to open cache file {}, error={} open_mode: [app={}][binary={}][in={}][out={}][trunc={}][ate={}]",
-                                    __FILE__, __LINE__, __FUNCTION__, this->get_thread_identifier(), cache_file_path_.c_str(), strerror(errno),
+                                    __FILE__, __LINE__, __func__, this->get_thread_identifier(), cache_file_path_.c_str(), strerror(errno),
                                     (mode & std::ios::app) != 0,
                                     (mode & std::ios::binary) != 0,
                                     (mode & std::ios::in) != 0,
@@ -1591,6 +1601,18 @@ namespace irods::experimental::io::s3_transport
             put_props.md5 = nullptr;
             put_props.expires = -1;
 
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+            if (this->config_.trailing_checksum_on_upload_enabled) {
+                // For chunked uploads with trailing checksum:
+                // 1. Set xAmzChecksumAlgorithm to tell S3/MinIO this upload uses CRC64NVME checksums
+                // 2. Don't set xAmzChecksumType (only for non-chunked uploads)
+                // 3. Set xAmzTrailer to declare which trailing headers we'll send
+                put_props.xAmzChecksumAlgorithm = "CRC64NVME";       // Declare checksum algorithm for multipart
+                put_props.xAmzChecksumType = nullptr;                // Not valid for chunked uploads
+                put_props.xAmzTrailer = "x-amz-checksum-crc64nvme";  // Declare the trailer
+            }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+
             upload_manager_.remaining = 0;
             upload_manager_.offset  = 0;
             upload_manager_.xml = "";
@@ -1618,16 +1640,16 @@ namespace irods::experimental::io::s3_transport
 
                 do {
                     logger::debug("{}:{} ({}) [[{}]] call S3_initiate_multipart [object_key={}]",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), object_key_.c_str());
+                            __FILE__, __LINE__, __func__, get_thread_identifier(), object_key_.c_str());
 
                     S3_initiate_multipart(&bucket_context_, object_key_.c_str(),
                             &put_props, &mpu_initial_handler, nullptr, 0, &upload_manager_);
 
                     logger::debug("{}:{} ({}) [[{}]] done call S3_initiate_multipart [object_key={}]",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), object_key_.c_str());
+                            __FILE__, __LINE__, __func__, get_thread_identifier(), object_key_.c_str());
 
                     logger::debug("{}:{} ({}) [[{}]] [manager.status={}]", __FILE__, __LINE__,
-                            __FUNCTION__, get_thread_identifier(), S3_get_status_name(upload_manager_.status));
+                            __func__, get_thread_identifier(), S3_get_status_name(upload_manager_.status));
 
                     if (upload_manager_.status != libs3_types::status_ok) {
                         s3_sleep( retry_wait_seconds );
@@ -1646,7 +1668,7 @@ namespace irods::experimental::io::s3_transport
                 }
 
                 logger::debug("{}:{} ({}) [[{}]] S3_initiate_multipart returned.  Upload ID = {}",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                        __FILE__, __LINE__, __func__, get_thread_identifier(),
                         data.upload_id.c_str());
 
                 upload_manager_.remaining = 0;
@@ -1690,12 +1712,12 @@ namespace irods::experimental::io::s3_transport
             status = s3_multipart_upload::cancel_callback::g_response_completion_status;
             if (status != libs3_types::status_ok) {
                 auto msg = fmt::format("{} - Error cancelling the multipart upload of S3 object: \"{}\"",
-                        __FUNCTION__,
+                        __func__,
                         object_key_);
                 if (status >= 0) {
                     msg += fmt::format(" - \"{}\"", S3_get_status_name(status));
                 }
-                logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                         msg.c_str() );
             }
         } // end mpu_cancel
@@ -1723,19 +1745,47 @@ namespace irods::experimental::io::s3_transport
                 }
 
                 if (error_codes::SUCCESS == data.last_error_code) { // If someone aborted, don't complete...
-
                     const auto msg = fmt::format("Multipart:  Completing key \"{}\" Upload ID \"{}\"", object_key_, upload_id);
-                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                             msg.c_str() );
 
                     std::uint64_t i;
+
                     auto xml = fmt::format("<CompleteMultipartUpload>\n");
                     for ( i = 0; i < data.etags.size() && !data.etags[i].empty(); i++ ) {
-                        xml += fmt::format("<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>\n", i + 1, data.etags[i]);
+                        // Check if we have a checksum for this part
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                        if (this->config_.trailing_checksum_on_upload_enabled &&
+                            i < data.checksum_vector.size() &&
+                            data.checksum_vector[i] != 0) {
+
+                            // Convert uint64_t checksum to big-endian bytes
+                            unsigned char checksum_bytes[8];
+                            uint64_t checksum_val = data.checksum_vector[i];
+                            for (int j = 0; j < 8; ++j) {
+                                checksum_bytes[7 - j] = static_cast<unsigned char>(checksum_val & 0xFF);
+                                checksum_val >>= 8;
+                            }
+
+                            // Base64 encode the checksum
+                            unsigned long encoded_len = 16;  // 8 bytes -> 12 chars + padding
+                            unsigned char encoded_checksum[16]{};
+                            base64_encode(checksum_bytes, 8, encoded_checksum, &encoded_len);
+                            std::string checksum_b64(reinterpret_cast<char*>(encoded_checksum), encoded_len);
+
+                            xml += fmt::format("<Part><PartNumber>{}</PartNumber><ETag>{}</ETag><ChecksumCRC64NVME>{}</ChecksumCRC64NVME></Part>\n",
+                                    i + 1, data.etags[i], checksum_b64);
+
+                        } else {
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                            xml += fmt::format("<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>\n", i + 1, data.etags[i]);
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                        }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
                     }
                     xml += fmt::format("</CompleteMultipartUpload>\n");
 
-                    logger::debug( "{}:{} ({}) [[{}]] [key={}] Request: {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                    logger::debug( "{}:{} ({}) [[{}]] [key={}] Request: {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                             object_key_.c_str(), xml.c_str() );
 
                     int manager_remaining = xml.size();
@@ -1745,6 +1795,7 @@ namespace irods::experimental::io::s3_transport
                         = { {s3_multipart_upload::commit_callback::on_response_properties,
                              s3_multipart_upload::commit_callback::on_response_completion },
                             s3_multipart_upload::commit_callback::on_response, nullptr };
+
                     do {
                         // On partial error, need to restart XML send from the beginning
                         upload_manager_.remaining = manager_remaining;
@@ -1756,12 +1807,13 @@ namespace irods::experimental::io::s3_transport
                                 &commit_handler,
                                 upload_id.c_str(),
                                 upload_manager_.remaining,
+                                nullptr,  // putProperties
                                 nullptr,
                                 config_.non_data_transfer_timeout_seconds * 1000,   // timeout (ms)
                                 &upload_manager_);
 
                         logger::debug("{}:{} ({}) [[{}]] [key={}][manager.status={}]", __FILE__, __LINE__,
-                                __FUNCTION__, get_thread_identifier(), object_key_.c_str(), S3_get_status_name(upload_manager_.status));
+                                __func__, get_thread_identifier(), object_key_.c_str(), S3_get_status_name(upload_manager_.status));
 
                         retry_cnt++;
 
@@ -1772,7 +1824,7 @@ namespace irods::experimental::io::s3_transport
                                 retry_cnt <= config_.retry_count_limit) {
 
                             logger::error("{}:{} ({}) [[{}]] S3_complete_multipart_upload returned error [status={}][object_key={}][attempt={}][retry_count_limit={}].  Sleeping for {} seconds",
-                                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                                    __FILE__, __LINE__, __func__, get_thread_identifier(),
                                     S3_get_status_name(upload_manager_.status), object_key_.c_str(), retry_cnt, config_.retry_count_limit, retry_wait_seconds);
                             s3_sleep( retry_wait_seconds );
                             retry_wait_seconds *= 2;
@@ -1788,7 +1840,7 @@ namespace irods::experimental::io::s3_transport
 
                     if (upload_manager_.status != libs3_types::status_ok && upload_manager_.status != libs3_types::status_request_timeout) {
                         auto msg  = fmt::format("{}  - Error putting the S3 object: \"{}\"",
-                                __FUNCTION__,
+                                __func__,
                                 object_key_);
                         if(upload_manager_.status >= 0) {
                             msg += fmt::format(" - \"{}\"", S3_get_status_name( upload_manager_.status ));
@@ -1907,7 +1959,7 @@ namespace irods::experimental::io::s3_transport
                         object_key_,
                         offset,
                         read_callback->content_length);
-                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                         msg.c_str());
 
                 std::uint64_t start_microseconds = get_time_in_microseconds();
@@ -1920,7 +1972,7 @@ namespace irods::experimental::io::s3_transport
                 double bw = (read_callback->content_length / (1024.0*1024.0)) /
                     ( (end_microseconds - start_microseconds) / 1000000.0 );
                 msg = fmt::format(" -- END -- BW={} MB/s", bw);
-                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__,
+                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__,
                         get_thread_identifier(), msg.c_str());
 
                 if (read_callback->status != libs3_types::status_ok) {
@@ -1940,7 +1992,7 @@ namespace irods::experimental::io::s3_transport
                 if (read_callback->status >= 0) {
                     msg += fmt::format(" - \"{}\"", S3_get_status_name( read_callback->status));
                 }
-                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__,
+                logger::debug("{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__,
                         get_thread_identifier(), msg.c_str());
 
                 this->set_error(ERROR(S3_GET_ERROR, msg.c_str()));
@@ -2030,7 +2082,7 @@ namespace irods::experimental::io::s3_transport
             std::int64_t content_length;
             std::vector<std::int64_t> part_sizes;
 
-            // resize the etags vector if necessary
+            // resize the etags and checksum vectors if necessary
             int resize_error = shm_obj.atomic_exec([this, &shm_obj](auto& data) {
 
                 if (constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD > data.etags.size()) {
@@ -2038,12 +2090,14 @@ namespace irods::experimental::io::s3_transport
                     std::int64_t maximum_number_etags_per_upload = constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD;
 
                     logger::debug( "{}:{} ({}) [[{}]] resize etags vector from {} to {}",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), data.etags.size(), maximum_number_etags_per_upload);
+                            __FILE__, __LINE__, __func__, get_thread_identifier(), data.etags.size(), maximum_number_etags_per_upload);
 
                     try {
                         data.etags.resize(constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD, types::shm_char_string("", shm_obj.get_allocator()));
+                        data.checksum_vector.resize(constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD);
+                        data.part_size_vector.resize(constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD);
                     } catch (boost::interprocess::bad_alloc &biba) {
-                        this->set_error(ERROR(S3_PUT_ERROR, "Error on reallocation of etags buffer in shared memory."));
+                        this->set_error(ERROR(S3_PUT_ERROR, "Error on reallocation of etags, checksum, or part size vectors in shared memory."));
                         data.last_error_code = error_codes::BAD_ALLOC;
                         return true;
                     }
@@ -2055,8 +2109,8 @@ namespace irods::experimental::io::s3_transport
             });
 
             if (resize_error) {
-                logger::error("Error on reallocation of etags buffer in shared memory.");
-                this->set_error(ERROR(S3_PUT_ERROR, "Error on reallocation of etags buffer in shared memory."));
+                logger::error("Error on reallocation of etags, checksum, or part size vectors in shared memory.");
+                this->set_error(ERROR(S3_PUT_ERROR, "Error on reallocation of etags, checksum, or part size vectors in shared memory."));
                 return;
             }
 
@@ -2115,6 +2169,7 @@ namespace irods::experimental::io::s3_transport
                         write_callback->content_length = content_length;
                     } else {
                         write_callback->content_length = part_sizes[part_number - start_part_number];
+logger::debug( "{}:{} ({}) [[{}]] write_callback->content_length is set to {} ", __FILE__, __LINE__, __func__, get_thread_identifier(), write_callback->content_length );
                     }
 
                     write_callback->sequence = part_number;
@@ -2125,7 +2180,7 @@ namespace irods::experimental::io::s3_transport
                             upload_id,
                             static_cast<int>(write_callback->content_length));
 
-                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                             msg.c_str() );
 
                     S3PutProperties put_props{};
@@ -2135,24 +2190,82 @@ namespace irods::experimental::io::s3_transport
                     // server encrypt flag not valid for part upload
                     put_props.useServerSideEncryption = false;
 
-                    logger::debug("{}:{} ({}) [[{}]] S3_upload_part (ctx, {}, props, handler, {}, "
-                           "uploadId, {}, 0, partData) bytes_this_thread={}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
-                           object_key_.c_str(), part_number,
-                           write_callback->content_length, (std::int64_t)bytes_this_thread);
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                    if (config_.trailing_checksum_on_upload_enabled) {
+                        write_callback->calculate_crc64_nvme = true;
 
-                    S3_upload_part(&bucket_context_, object_key_.c_str(), &put_props,
-                            &put_object_handler, part_number, upload_id.c_str(),
-                            write_callback->content_length, 0, 120000, write_callback.get());
+                        // Trailing headers callback - returns the CRC64/NVME checksum
+                        auto trailing_headers_cb = [](int maxHeaders, S3NameValue* headers, void* callbackData) -> int {
+                            if (maxHeaders < 1) {
+                                return -1;
+                            }
 
-                    // zero out bytes_written in case of failure and re-run
-                    write_callback->bytes_written = 0;
+                            // Cast void* back to the callback object type
+                            auto* cb = static_cast<s3_multipart_upload::callback_for_write_to_s3_base<CharT>*>(callbackData);
 
-                    logger::debug("{}:{} ({}) [[{}]] S3_upload_part returned [part={}][status={}].",
-                            __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), part_number,
-                            S3_get_status_name(write_callback->status));
+                            // Get the checksum from the hasher (accumulated during data upload).
+                            // Store in cb->trailing_checksum_value so it outlives this lambda call.
+                            cb->hasher.digest(cb->trailing_checksum_value);
+                            logger::debug("{}:{} ({}) checksum from hasher: [{}]", __FILE__, __LINE__, __func__, cb->trailing_checksum_value);
+
+                            // Remove the "crc64nvme:" prefix from the checksum string
+                            remove_checksum_prefix(cb->trailing_checksum_value, irods::CRC64NVME_NAME + ":");
+
+                            headers[0].name = "x-amz-checksum-crc64nvme";
+                            headers[0].value = cb->trailing_checksum_value.c_str();
+                            logger::debug("{}:{} ({}) part trailing checksum header: {}={}",
+                                    __FILE__, __LINE__, __func__,
+                                    headers[0].name, headers[0].value);
+                            return 1;
+                        };
+
+                        // Set up put properties for chunked upload with trailing checksum
+                        put_props.contentEncoding = "aws-chunked";
+                        put_props.xAmzTrailer = "x-amz-checksum-crc64nvme";
+                        put_props.xAmzDecodedContentLength = write_callback->content_length;
+
+                        S3PutObjectHandlerChunked chunked_handler = {
+                            {
+                                s3_multipart_upload::callback_for_write_to_s3_base<CharT>::on_response_properties,
+                                s3_multipart_upload::callback_for_write_to_s3_base<CharT>::on_response_completion
+                            },
+                            s3_multipart_upload::callback_for_write_to_s3_base<CharT>::invoke_callback,
+                            trailing_headers_cb
+                        };
+
+                        logger::debug("{}:{} ({}) [[{}]] S3_upload_part_chunked (ctx, {}, props, {}, "
+                               "uploadId, 0, partData) bytes_this_thread={} [trailing_checksum=enabled]",
+                               __FILE__, __LINE__, __func__, get_thread_identifier(),
+                               object_key_.c_str(), part_number,
+                               (std::int64_t)bytes_this_thread);
+
+                        S3_upload_part_chunked(&bucket_context_, object_key_.c_str(), &put_props,
+                                part_number, upload_id.c_str(),
+                                nullptr, 120000, &chunked_handler, write_callback.get());
+
+                        logger::debug("{}:{} ({}) [[{}]] S3_upload_part_chunked returned [part={}][status={}].",
+                                __FILE__, __LINE__, __func__, get_thread_identifier(), part_number,
+                                S3_get_status_name(write_callback->status));
+                    } else {
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                        logger::debug("{}:{} ({}) [[{}]] S3_upload_part (ctx, {}, props, handler, {}, "
+                               "uploadId, {}, 0, partData) bytes_this_thread={}", __FILE__, __LINE__, __func__, get_thread_identifier(),
+                               object_key_.c_str(), part_number,
+                               write_callback->content_length, (std::int64_t)bytes_this_thread);
+
+                        S3_upload_part(&bucket_context_, object_key_.c_str(), &put_props,
+                                &put_object_handler, part_number, upload_id.c_str(),
+                                write_callback->content_length, 0, 120000, write_callback.get());
+
+                        logger::debug("{}:{} ({}) [[{}]] S3_upload_part returned [part={}][status={}].",
+                                __FILE__, __LINE__, __func__, get_thread_identifier(), part_number,
+                                S3_get_status_name(write_callback->status));
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                    }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
 
                     msg = fmt::format("Multipart:  -- END --");
-                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                    logger::debug( "{}:{} ({}) [[{}]] {}", __FILE__, __LINE__, __func__, get_thread_identifier(),
                             msg.c_str() );
 
                     retry_cnt += 1;
@@ -2171,7 +2284,7 @@ namespace irods::experimental::io::s3_transport
                             logger::error(
                                     "{}:{} ({}) [[{}]] S3_upload_part returned error [status={}][attempt={}][retry_count_limit={}].  "
                                     "Sleeping between {} and {} seconds",
-                                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
+                                    __FILE__, __LINE__, __func__, get_thread_identifier(),
                                     S3_get_status_name(write_callback->status), retry_cnt, config_.retry_count_limit,
                                     retry_wait_seconds >> 1, retry_wait_seconds);
 
@@ -2181,6 +2294,13 @@ namespace irods::experimental::io::s3_transport
                                 retry_wait_seconds = config_.max_retry_wait_seconds;
                             }
 
+                            // Reset bytes_written and hasher for retry
+                            write_callback->bytes_written = 0;
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                            if (config_.trailing_checksum_on_upload_enabled) {
+                                irods::getHasher(irods::CRC64NVME_NAME.data(), write_callback->hasher);
+                            }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
                         }
                     }
 
@@ -2201,18 +2321,75 @@ namespace irods::experimental::io::s3_transport
                             data.last_error_code = error_codes::UPLOAD_FILE_ERROR;
                         });
                     }
+
+                    // break out of for loop on part upload failure
+                    break;
                 }
                 write_callback->bytes_written = 0;
 
-                // break out of for loop if we timed out reading from circular buffer
+                // break out of for-loop if we timed out reading from circular buffer
                 if (circular_buffer_read_timeout) {
                     break;
                 }
 
+                // save the checksum
+                std::string checksum_str;
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                write_callback->hasher.digest(checksum_str);
+                logger::debug("{}:{} ({}) checksum_str=[{}]", __FILE__, __LINE__, __func__, checksum_str);
+
+                // delete the "crc64nvme:" prefix from the checksum string
+                if (checksum_str.length() > irods::CRC64NVME_NAME.length() + 1) {
+                   checksum_str = checksum_str.substr(irods::CRC64NVME_NAME.length() + 1);
+                } else {
+                    checksum_str = "";
+                }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+
+                // save the actual part size and decoded checksum to shared memory
+                auto actual_part_size = write_callback->content_length;
+                shm_obj.atomic_exec([&checksum_str, part_number, actual_part_size](auto& data) {
+                    // save actual part size (not bytes_this_thread which is total for the thread)
+                    data.part_size_vector[part_number-1] = actual_part_size;
+
+                    // decode checksum as uint64_t and save it
+			        if (!checksum_str.empty()) {
+                        unsigned long out_len = 8;
+						unsigned char response[8]{};
+                        auto err = base64_decode(reinterpret_cast<const unsigned char*>(checksum_str.c_str()),
+                                     checksum_str.size(),
+                                     reinterpret_cast<unsigned char*>(response),
+                                     &out_len);
+                        if (err < 0) {
+                            logger::error("{}:{} ({}) Base64 decoding of [{}] failed.",
+					    			__FILE__, __LINE__, __func__, checksum_str);
+                            data.checksum_vector[part_number-1] = 0;
+							return;
+						}
+
+						// The checksum was stored in big endian format before the base64 encoding.
+						// Convert this back to a uint64_t by interpreting the 8 bytes as big endian.
+						uint64_t val = 0;
+						for (int i = 0; i < 8; ++i) {
+						    val += (response[i]) * (static_cast<uint64_t>(0x01) << ((7-i) * 8));
+						}
+                        data.checksum_vector[part_number-1] = val;
+					} else {
+                        data.checksum_vector[part_number-1] = 0;
+					}
+                });
+
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                // Reset hasher for next part
+                if (config_.trailing_checksum_on_upload_enabled) {
+                    irods::getHasher(irods::CRC64NVME_NAME.data(), write_callback->hasher);
+                }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+
             } // for
 
             logger::debug("{}:{} ({}) [[{}]] Breaking out of circular_buffer_read loop.  End part number = {}",
-                    __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(), end_part_number);
+                    __FILE__, __LINE__, __func__, get_thread_identifier(), end_part_number);
         }
 
         error_codes s3_upload_file(bool read_from_cache = false)
@@ -2285,18 +2462,81 @@ namespace irods::experimental::io::s3_transport
                 // zero out bytes_written in case of failure and re-run
                 write_callback->bytes_written = 0;
 
-                logger::debug("{}:{} ({}) [[{}]] S3_put_object(ctx, {}, "
-                       "{}, put_props, 0, &putObjectHandler, &data)",
-                       __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
-                       object_key_.c_str(),
-                       write_callback->content_length);
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                if (config_.trailing_checksum_on_upload_enabled) {
+                    write_callback->calculate_crc64_nvme = true;
 
-                S3_put_object(&bucket_context_, object_key_.c_str(), write_callback->content_length,
-                        &put_props, 0, 0, &put_object_handler, write_callback.get());
+                    // Trailing headers callback - returns the CRC64/NVME checksum
+                    // This is called AFTER all data has been sent via the data callback,
+                    // so the hasher will have accumulated the complete checksum.
+                    auto trailing_headers_cb = [](int maxHeaders, S3NameValue* headers, void* callbackData) -> int {
+                        if (maxHeaders < 1) {
+                            return -1;
+                        }
 
-                logger::debug("{}:{} ({}) [[{}]] S3_put_object returned [status={}].",
-                        __FILE__, __LINE__, __FUNCTION__, get_thread_identifier(),
-                        S3_get_status_name(write_callback->status));
+                        // Cast void* back to the callback object type
+                        auto* cb = static_cast<s3_upload::callback_for_write_to_s3_base<CharT>*>(callbackData);
+
+                        // Get the checksum from the hasher (accumulated during data upload)
+                        // Get the checksum from the hasher (accumulated during data upload).
+                        // Store in cb->trailing_checksum_value so it outlives this lambda call.
+                        cb->hasher.digest(cb->trailing_checksum_value);
+                        logger::debug("{}:{} ({}) checksum from hasher: [{}]", __FILE__, __LINE__, __func__, cb->trailing_checksum_value);
+
+                        // Remove the "crc64nvme:" prefix from the checksum string
+                        remove_checksum_prefix(cb->trailing_checksum_value, irods::CRC64NVME_NAME + ":");
+
+                        headers[0].name = "x-amz-checksum-crc64nvme";
+                        headers[0].value = cb->trailing_checksum_value.c_str();
+                        logger::debug("{}:{} ({}) trailing checksum header: {}={}",
+                                __FILE__, __LINE__, __func__,
+                                headers[0].name, headers[0].value);
+                        return 1;
+                    };
+
+                    // Set up put properties for chunked upload with trailing checksum
+                    put_props.contentEncoding = "aws-chunked";
+                    put_props.xAmzTrailer = "x-amz-checksum-crc64nvme";
+                    put_props.xAmzDecodedContentLength = write_callback->content_length;
+
+                    S3PutObjectHandlerChunked chunked_handler = {
+                        {
+                            s3_upload::callback_for_write_to_s3_base<CharT>::on_response_properties,
+                            s3_upload::callback_for_write_to_s3_base<CharT>::on_response_completion
+                        },
+                        s3_upload::callback_for_write_to_s3_base<CharT>::invoke_callback,
+                        trailing_headers_cb
+                    };
+
+                    logger::debug("{}:{} ({}) [[{}]] S3_put_object_chunked(ctx, {}, "
+                           "put_props, 0, &chunkedHandler, &data) [trailing_checksum=enabled]",
+                           __FILE__, __LINE__, __func__, get_thread_identifier(),
+                           object_key_.c_str());
+
+                    S3_put_object_chunked(&bucket_context_, object_key_.c_str(),
+                            &put_props, nullptr, 0, &chunked_handler, write_callback.get());
+
+                    logger::debug("{}:{} ({}) [[{}]] S3_put_object_chunked returned [status={}].",
+                            __FILE__, __LINE__, __func__, get_thread_identifier(),
+                            S3_get_status_name(write_callback->status));
+                } else {
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                    // Standard upload without trailing checksum
+                    logger::debug("{}:{} ({}) [[{}]] S3_put_object(ctx, {}, "
+                           "{}, put_props, 0, &putObjectHandler, &data)",
+                           __FILE__, __LINE__, __func__, get_thread_identifier(),
+                           object_key_.c_str(),
+                           write_callback->content_length);
+
+                    S3_put_object(&bucket_context_, object_key_.c_str(), write_callback->content_length,
+                            &put_props, 0, 0, &put_object_handler, write_callback.get());
+
+                    logger::debug("{}:{} ({}) [[{}]] S3_put_object returned [status={}].",
+                            __FILE__, __LINE__, __func__, get_thread_identifier(),
+                            S3_get_status_name(write_callback->status));
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+                }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
 
                 if (write_callback->status != libs3_types::status_ok) {
 

--- a/s3_transport/include/irods/private/s3_transport/util.hpp
+++ b/s3_transport/include/irods/private/s3_transport/util.hpp
@@ -6,6 +6,7 @@
 // iRODS includes
 #include <irods/rcMisc.h>
 #include <irods/transport/transport.hpp>
+#include <irods/rodsDef.h>
 
 // misc includes
 #include <nlohmann/json.hpp>
@@ -58,9 +59,13 @@ namespace irods::experimental::io::s3_transport
         // must have enough space for the memory algorithm and reserved area but there is
         // no way of knowing the size for these.  It is stated that 100*sizeof(void*) would
         // be enough.
-        static constexpr std::int64_t        MAX_S3_SHMEM_SIZE{100*sizeof(void*) + sizeof(shared_data::multipart_shared_data) +
-                                                          MAXIMUM_NUMBER_ETAGS_PER_UPLOAD * (BYTES_PER_ETAG + 1) +
-                                                          UPLOAD_ID_SIZE + 1};
+        //
+        // Each part (maximum count of MAXIMUM_NUMBER_ETAGS_PER_UPLOAD) can have an ETAG, 8 bytes for part size,
+		// and 8 bytes for CRC64/NVME checksum
+        static constexpr std::int64_t  MAX_S3_SHMEM_SIZE{100*sizeof(void*) +
+			sizeof(shared_data::multipart_shared_data) +
+			MAXIMUM_NUMBER_ETAGS_PER_UPLOAD * (BYTES_PER_ETAG + 16 + 1) +
+			UPLOAD_ID_SIZE + 1};
 
         static const int                DEFAULT_SHARED_MEMORY_TIMEOUT_IN_SECONDS{900};
         inline static const std::string SHARED_MEMORY_KEY_PREFIX{"irods_s3_transport-shm-"};
@@ -74,6 +79,11 @@ namespace irods::experimental::io::s3_transport
                                const libs3_types::bucket_context& saved_bucket_context,
                                libs3_types::status& pStatus,
                                std::uint64_t thread_id = 0);
+
+    // Remove the prefix from the beginning of the checksum_str.
+    // If the prefix is not detected the checksum_str is unaltered.
+    void remove_checksum_prefix(std::string& checksum_str, const std::string& checksum_prefix);
+
     // Sleep between _s / 2 and _s seconds.
     // The random addition ensures that threads don't all cluster up and retry
     // at the same time (dogpile effect)
@@ -98,8 +108,8 @@ namespace irods::experimental::io::s3_transport
         /* Below used for the upload completion command, need to send in XML */
         std::string              xml;
 
-        std::int64_t                  remaining;
-        std::int64_t                  offset;
+        std::int64_t             remaining;
+        std::int64_t             offset;
         libs3_types::status      status;            /* status returned by libs3 */
         std::string              object_key;
         std::string              shmem_key;

--- a/s3_transport/src/s3_transport.cpp
+++ b/s3_transport/src/s3_transport.cpp
@@ -172,9 +172,9 @@ namespace irods::experimental::io::s3_transport
         upload_manager.xml = const_cast<char*>(xml.c_str());
         upload_manager.offset = 0;
 
-        logger::debug("{}:{} ({}) [[{}]] Multipart:  Restoring object {}", __FILE__, __LINE__, __FUNCTION__, thread_id, object_key.c_str());
+        logger::debug("{}:{} ({}) [[{}]] Multipart:  Restoring object {}", __FILE__, __LINE__, __func__, thread_id, object_key.c_str());
 
-        logger::debug("{}:{} ({}) [[{}]] [key={}] Request: {}", __FILE__, __LINE__, __FUNCTION__,
+        logger::debug("{}:{} ({}) [[{}]] [key={}] Request: {}", __FILE__, __LINE__, __func__,
                 thread_id, object_key.c_str(), xml.c_str() );
 
         S3RestoreObjectHandler commit_handler
@@ -186,12 +186,12 @@ namespace irods::experimental::io::s3_transport
                 &commit_handler, upload_manager.remaining, nullptr, 0, &upload_manager);
 
         logger::debug("{}:{} ({}) [[{}]] [key={}][manager.status={}]", __FILE__, __LINE__,
-                __FUNCTION__, thread_id, object_key.c_str(), S3_get_status_name(upload_manager.status));
+                __func__, thread_id, object_key.c_str(), S3_get_status_name(upload_manager.status));
 
         if (upload_manager.status != S3StatusOK) {
 
             logger::error("{}:{} ({}) [[{}]] S3_restore_object returned error [status={}][object_key={}].",
-                    __FILE__, __LINE__, __FUNCTION__, thread_id,
+                    __FILE__, __LINE__, __func__, thread_id,
                     S3_get_status_name(upload_manager.status), object_key.c_str());
 
             return ERROR(REPLICA_STAGING_FAILED, fmt::format("Object is in {}, but scheduling restoration failed.", storage_class));
@@ -239,36 +239,36 @@ namespace irods::experimental::io::s3_transport
         if(status != libs3_types::status_ok && status != S3StatusHttpErrorNotFound) {
 
             logger::error( "{}:{} [{}] [[{}]]  libs3_types::status: [{}] - {}",
-                    __FILE__, __LINE__, __FUNCTION__, thread_id, S3_get_status_name( status ), static_cast<int>(status) );
+                    __FILE__, __LINE__, __func__, thread_id, S3_get_status_name( status ), static_cast<int>(status) );
             if (saved_bucket_context.hostName) {
                 logger::error( "{}:{} [{}] [[{}]]  S3Host: {}",
-                        __FILE__, __LINE__, __FUNCTION__, thread_id, saved_bucket_context.hostName );
+                        __FILE__, __LINE__, __func__, thread_id, saved_bucket_context.hostName );
             }
 
             logger::error( "{}:{} [{}] [[{}]]  Function: {}",
-                    __FILE__, __LINE__, __FUNCTION__, thread_id, function.c_str() );
+                    __FILE__, __LINE__, __func__, thread_id, function.c_str() );
 
             if (error) {
 
                 if (error->message) {
                     logger::error( "{}:{} [{}] [[{}]]  Message: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->message);
+                            __FILE__, __LINE__, __func__, thread_id, error->message);
                 }
                 if (error->resource) {
                     logger::error( "{}:{} [{}] [[{}]]  Resource: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->resource);
+                            __FILE__, __LINE__, __func__, thread_id, error->resource);
                 }
                 if (error->furtherDetails) {
                     logger::error( "{}:{} [{}] [[{}]]  Further Details: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->furtherDetails);
+                            __FILE__, __LINE__, __func__, thread_id, error->furtherDetails);
                 }
                 if (error->extraDetailsCount) {
                     logger::error( "{}:{} [{}] [[{}]]{}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, "  Extra Details:");
+                            __FILE__, __LINE__, __func__, thread_id, "  Extra Details:");
 
                     for (int i = 0; i < error->extraDetailsCount; i++) {
                         logger::error( "{}:{} [{}] [[{}]]    {}: {}",
-                                __FILE__, __LINE__, __FUNCTION__, thread_id, error->extraDetails[i].name,
+                                __FILE__, __LINE__, __func__, thread_id, error->extraDetails[i].name,
                                 error->extraDetails[i].value);
                     }
                 }
@@ -277,42 +277,50 @@ namespace irods::experimental::io::s3_transport
         } else {
 
             logger::debug( "{}:{} [{}] [[{}]]  libs3_types::status: [{}] - {}",
-                    __FILE__, __LINE__, __FUNCTION__, thread_id, S3_get_status_name( status ), static_cast<int>(status) );
+                    __FILE__, __LINE__, __func__, thread_id, S3_get_status_name( status ), static_cast<int>(status) );
             if (saved_bucket_context.hostName) {
                 logger::debug( "{}:{} [{}] [[{}]]  S3Host: {}",
-                        __FILE__, __LINE__, __FUNCTION__, thread_id, saved_bucket_context.hostName );
+                        __FILE__, __LINE__, __func__, thread_id, saved_bucket_context.hostName );
             }
 
             logger::debug( "{}:{} [{}] [[{}]]  Function: {}",
-                    __FILE__, __LINE__, __FUNCTION__, thread_id, function.c_str() );
+                    __FILE__, __LINE__, __func__, thread_id, function.c_str() );
 
             if (error) {
 
                 if (error->message) {
                     logger::debug( "{}:{} [{}] [[{}]]  Message: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->message);
+                            __FILE__, __LINE__, __func__, thread_id, error->message);
                 }
                 if (error->resource) {
                     logger::debug( "{}:{} [{}] [[{}]]  Resource: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->resource);
+                            __FILE__, __LINE__, __func__, thread_id, error->resource);
                 }
                 if (error->furtherDetails) {
                     logger::debug( "{}:{} [{}] [[{}]]  Further Details: {}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, error->furtherDetails);
+                            __FILE__, __LINE__, __func__, thread_id, error->furtherDetails);
                 }
                 if (error->extraDetailsCount) {
                     logger::debug( "{}:{} [{}] [[{}]]{}",
-                            __FILE__, __LINE__, __FUNCTION__, thread_id, "  Extra Details:");
+                            __FILE__, __LINE__, __func__, thread_id, "  Extra Details:");
 
                     for (int i = 0; i < error->extraDetailsCount; i++) {
                         logger::debug( "{}:{} [{}] [[{}]]    {}: {}",
-                                __FILE__, __LINE__, __FUNCTION__, thread_id, error->extraDetails[i].name,
+                                __FILE__, __LINE__, __func__, thread_id, error->extraDetails[i].name,
                                 error->extraDetails[i].value);
                     }
                 }
             }
        }
     }  // end store_and_log_status
+
+    // Remove the prefix from the beginning of the checksum_str.
+    // If the prefix is not detected the checksum_str is unaltered.
+    void remove_checksum_prefix(std::string& checksum_str, const std::string& checksum_prefix) {
+        if (checksum_str.starts_with(checksum_prefix)) {
+            checksum_str = checksum_str.substr(checksum_prefix.length());
+        }
+    } // end remove_checksum_prefix
 
     // Returns timestamp in usec for delta-t comparisons
     // std::uint64_t provides plenty of headroom

--- a/unit_tests/src/test_s3_transport.cpp
+++ b/unit_tests/src/test_s3_transport.cpp
@@ -3,7 +3,12 @@
 #include "irods/private/s3_transport/s3_transport.hpp"
 #include "irods/private/s3_transport/util.hpp"
 #include "irods/private/s3_transport/multipart_shared_data.hpp"
+#include "irods/private/s3_transport/logging_category.hpp"
+
+#include <irods/miscServerFunct.hpp>
 #include <irods/filesystem/filesystem.hpp>
+#include <irods/library_features.h>
+
 #include <irods/dstream.hpp>
 #include <mutex>
 #include <condition_variable>
@@ -18,8 +23,7 @@
 #include <sstream>
 #include <string_view>
 #include <fmt/format.h>
-#include <irods/miscServerFunct.hpp>
-#include "irods/private/s3_transport/logging_category.hpp"
+#include <filesystem>
 
 // to run the following unit tests, the aws command line utility needs to be available in
 // the path and "aws configure" needs to be run to set up the keys
@@ -33,14 +37,8 @@ using s3_transport_config = irods::experimental::io::s3_transport::config;
 namespace fs = irods::experimental::filesystem;
 namespace io = irods::experimental::io;
 
-std::string keyfile = []() {
-    const char* env_keyfile = std::getenv("S3_TEST_KEYFILE");
-    return env_keyfile ? std::string(env_keyfile) : "/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair";
-}();
-std::string hostname = []() {
-    const char* env_hostname = std::getenv("S3_TEST_HOSTNAME");
-    return env_hostname ? std::string(env_hostname) : "s3.amazonaws.com";
-}();
+std::string keyfile = "/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair";
+std::string hostname = "s3.amazonaws.com";
 
 const unsigned int S3_DEFAULT_NON_DATA_TRANSFER_TIMEOUT_SECONDS = 300;
 
@@ -160,6 +158,33 @@ void check_download_results(const std::string& bucket_name, const std::string& f
 
     REQUIRE(0 == cmp_return_val);
 }
+
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
+void check_upload_checksum_results(const std::string& bucket_name, const std::string& filename, const std::string& object_prefix)
+{
+    const auto checksum_output_file = fmt::format("{}.checksum_output", filename);
+    const auto aws_cmd = fmt::format(
+            "aws --endpoint-url http://{} s3api get-object-attributes "
+            "--bucket {} --key {}{} "
+            "--object-attributes Checksum "
+            "--query 'Checksum.ChecksumCRC64NVME' --output text > {}",
+            hostname, bucket_name, object_prefix, filename, checksum_output_file);
+
+    fmt::print("{}\n", aws_cmd);
+    int rc = std::system(aws_cmd.c_str());
+    REQUIRE(0 == rc);
+
+    std::ifstream checksum_ifs(checksum_output_file);
+    REQUIRE(checksum_ifs.good());
+    std::string checksum;
+    std::getline(checksum_ifs, checksum);
+    checksum_ifs.close();
+    std::filesystem::remove(checksum_output_file.c_str());
+
+    fmt::print("CRC64NVME checksum: {}\n", checksum);
+    REQUIRE(!checksum.empty());
+}
+#endif
 
 void check_read_write_results(const std::string& bucket_name, const std::string& filename, const std::string& object_prefix)
 {
@@ -498,7 +523,11 @@ void do_upload_process(const std::string& bucket_name,
             upload_part(hostname.c_str(), bucket_name.c_str(), access_key.c_str(),
                     secret_access_key.c_str(), filename.c_str(), object_prefix.c_str(),
                     process_count, process_number, true, true, expected_cache_flag);
-            return;
+
+            // This has to be an exit rather than a return.  The forked process continued when this was a return which caused
+            // unexpected results.  This needs to be the _exit() system call (std::_Exit()) rather than exit() in the forked
+            // child process to ensure only the parent process performs standard I/O (stdio) cleanup and resource deallocation.
+            std::_Exit(0);
         }
 
         fmt::print("{}:{} ({}) [{}] started process {}\n", __FILE__, __LINE__, __FUNCTION__,
@@ -535,7 +564,10 @@ void do_download_process(const std::string& bucket_name,
                     secret_access_key.c_str(), filename.c_str(), object_prefix.c_str(),
                     process_count, process_number, expected_cache_flag);
 
-            return;
+            // This has to be an exit rather than a return.  The forked process continued when this was a return which caused
+            // unexpected results.  This needs to be the _exit() system call (std::_Exit()) rather than exit() in the forked
+            // child process to ensure only the parent process performs standard I/O (stdio) cleanup and resource deallocation.
+            std::_Exit(0);
         }
 
         fmt::print("{}:{} ({}) [{}] started process {}\n", __FILE__, __LINE__, __FUNCTION__,
@@ -789,8 +821,14 @@ TEST_CASE("shmem tests 2", "[shmem2]")
         };
 
         std::string object_key = "dir1/dir2/large_file";
+
         std::string shmem_key = constants::SHARED_MEMORY_KEY_PREFIX +
-                std::to_string(std::hash<std::string>{}(object_key));
+                std::to_string(std::hash<std::string>{}("/" + object_key));
+
+        // Remove any leftover shared memory from a previous run to avoid
+        // deadlocking on an abandoned interprocess mutex.
+        bi::shared_memory_object::remove(shmem_key.c_str());
+        bi::named_mutex::remove(shmem_key.c_str());
 
         const time_t now = time(0);
         bi::managed_shared_memory shm{bi::open_or_create, shmem_key.c_str(), constants::MAX_S3_SHMEM_SIZE};
@@ -800,17 +838,21 @@ TEST_CASE("shmem tests 2", "[shmem2]")
 
         // set some inconsistent state in the object in shared memory
         // including leaving the interprocess recursive mutex locked
-        // set access time to a value that is considered expired
+        // set access time to a value that is considered expired (must be > timeout, not ==)
         (object->thing.ref_count)++;
         (object->thing.threads_remaining_to_close)++;
         object->access_mutex.lock();
-        object->last_access_time_in_seconds = now - 20;
+        object->last_access_time_in_seconds = now - 21;
 
         int thread_count = 7;
         std::string filename = "large_file";
         std::string object_prefix = "dir1/dir2/";
         bool expected_cache_flag = false;
         do_upload_thread(bucket_name, filename, object_prefix, keyfile, thread_count, expected_cache_flag);
+
+        // Clean up shared memory to prevent stale state on next run
+        bi::shared_memory_object::remove(shmem_key.c_str());
+        bi::named_mutex::remove(shmem_key.c_str());
     }
 
     remove_bucket(bucket_name);
@@ -943,6 +985,7 @@ TEST_CASE("s3_transport_upload_multiple_threads", "[upload][thread]")
     remove_bucket(bucket_name);
 }
 
+#ifdef IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
 TEST_CASE("s3_transport_upload_trailing_checksum", "[upload][thread][trailing_checksum]")
 {
 
@@ -958,6 +1001,7 @@ TEST_CASE("s3_transport_upload_trailing_checksum", "[upload][thread][trailing_ch
     {
         do_upload_thread(bucket_name, filename, object_prefix, keyfile, thread_count, expected_cache_flag,
                 "https", "both", trailing_checksum_on_upload_enabled);
+        check_upload_checksum_results(bucket_name, filename, object_prefix);
     }
 
     SECTION("upload large file with multiple threads and trailing checksum")
@@ -966,10 +1010,12 @@ TEST_CASE("s3_transport_upload_trailing_checksum", "[upload][thread][trailing_ch
         filename = "large_file";
         do_upload_thread(bucket_name, filename, object_prefix, keyfile, thread_count, expected_cache_flag,
                 "https", "both", trailing_checksum_on_upload_enabled);
+        check_upload_checksum_results(bucket_name, filename, object_prefix);
     }
 
     remove_bucket(bucket_name);
 }
+#endif // IRODS_LIBRARY_FEATURE_CHECKSUM_ALGORITHM_CRC64NVME
 
 TEST_CASE("s3_transport_download_large_multiple_threads", "[download][thread]")
 {


### PR DESCRIPTION
This is to add support for sending CRC64/NVME checksums on uploads.

The following has been tested:

1. Debian 12 - Full  suite against both MinIO and AWS.
2. Debian 13 - Tested test_irods_resource_plugin_s3_minio.Test_S3_NoCache_Trailing_Checksum suite against MinIO.
3. EL9 - Tested test_irods_resource_plugin_s3_minio.Test_S3_NoCache_Trailing_Checksum suite against MinIO.
4. Ubuntu 22 - Tested test_irods_resource_plugin_s3_minio.Test_S3_NoCache_Trailing_Checksum suite against MinIO.
5. Ubuntu 24 - Tested test_irods_resource_plugin_s3_minio.Test_S3_NoCache_Trailing_Checksum suite against MinIO.


For issue 2285:

- Added CRC64/NVME to body of CompleteMultipartUpload.
- Added headers to CreateMultipartUpload identifying the checksum type that should be expected.
- Add trailing checksum for UploadPart
- Added trailing checksum for PutObject
- Added chunked encoding for UploadPart and PutObject in support of the previous two bullets.
- Added resource context string option to enable trailing checksum (ENABLE_TRAILING_CHECKSUM_ON_UPLOAD).

For 2284:

- Ignore case when parsing the XML response for GetObjectAttributes. This was needed as it was determined that MinIO does not send the proper case.