### PR TITLE
[2301] Fix error when irsync a zero byte file.

### DIFF
--- a/libs3/src/request.c
+++ b/libs3/src/request.c
@@ -1296,18 +1296,33 @@ static S3Status setup_curl(Request* request, const RequestParams* params, const 
 		request->headers = curl_slist_append(request->headers, values->fieldName); \
 	}
 
-	// Would use CURLOPT_INFILESIZE_LARGE, but it is buggy in libcurl
 	// jjames - added HttpRequestTypeCOPY because Ceph S3 requires it
 	if ((params->httpRequestType == HttpRequestTypePUT) || (params->httpRequestType == HttpRequestTypePOST) ||
 	    params->httpRequestType == HttpRequestTypeCOPY)
 	{
 		// Check if we're using chunked encoding (toS3CallbackTotalSize == -1)
 		if (params->toS3CallbackTotalSize < 0) {
-			// Chunked encoding - do NOT set Content-Length
-			// Explicitly set Transfer-Encoding: chunked for S3-compatible servers like MinIO
-			request->headers = curl_slist_append(request->headers, "Transfer-Encoding: chunked");
+			if (params->putProperties && params->putProperties->xAmzTrailer) {
+				// aws-chunked with trailing checksum (STREAMING-UNSIGNED-PAYLOAD-TRAILER).
+				// Explicitly set "Transfer-Encoding: chunked" for S3-compatible servers.
+				request->headers = curl_slist_append(request->headers, "Transfer-Encoding: chunked");
+			} else {
+				// Chunked without a trailing checksum produces UNSIGNED-PAYLOAD + chunked,
+				// which AWS S3 rejects with 501. Fall back to "Content-Length: 0". The only
+				// path that reaches here without xAmzTrailer is a 0-byte upload where
+				// content_length was passed as -1 (UNKNOWN_OBJECT_SIZE).
+				curl_easy_setopt(request->curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)0);
+				request->headers = curl_slist_append(request->headers, "Content-Length: 0");
+				request->headers = curl_slist_append(request->headers, "Transfer-Encoding:");
+			}
 		} else {
-			// Normal PUT with known size - set Content-Length
+			// Normal PUT with known size - set Content-Length and tell libcurl the exact size.
+			// Setting CURLOPT_INFILESIZE_LARGE prevents libcurl from falling back to
+			// "Transfer-Encoding: chunked" for uploads where the read callback returns 0 bytes
+			// immediately (e.g. 0-byte files), which would produce UNSIGNED-PAYLOAD + chunked
+			// — a combination that AWS S3 rejects with 501 Not Implemented.
+			curl_easy_setopt(request->curl, CURLOPT_INFILESIZE_LARGE,
+			                 (curl_off_t)params->toS3CallbackTotalSize);
 			char header[256];
 			snprintf(header, sizeof(header), "Content-Length: %llu", (unsigned long long) params->toS3CallbackTotalSize);
 			request->headers = curl_slist_append(request->headers, header);

--- a/s3_resource/src/s3_resource.cpp
+++ b/s3_resource/src/s3_resource.cpp
@@ -1804,6 +1804,9 @@ irods::error s3PutCopyFile(
     if ( putProps && server_encrypt )
         putProps->useServerSideEncryption = true;
     putProps->expires = -1;
+    // Default the xAmzDecodedContentLength to -1 (UNKNOWN).  This is only used for chunked
+    // encoding with trailing CRC64NVME header.
+    putProps->xAmzDecodedContentLength = -1;
     std::string storage_class = s3_get_storage_class_from_configuration(_prop_map);
     putProps->xAmzStorageClass = storage_class.c_str();
 

--- a/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
+++ b/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
@@ -2186,6 +2186,7 @@ logger::debug( "{}:{} ({}) [[{}]] write_callback->content_length is set to {} ",
                     S3PutProperties put_props{};
                     put_props.md5 = nullptr;
                     put_props.expires = -1;
+                    put_props.xAmzDecodedContentLength = -1;
 
                     // server encrypt flag not valid for part upload
                     put_props.useServerSideEncryption = false;
@@ -2458,6 +2459,7 @@ logger::debug( "{}:{} ({}) [[{}]] write_callback->content_length is set to {} ",
                 put_props.expires = -1;
                 put_props.useServerSideEncryption = config_.server_encrypt_flag;
                 put_props.xAmzStorageClass = config_.s3_storage_class.c_str();
+                put_props.xAmzDecodedContentLength = -1;
 
                 // zero out bytes_written in case of failure and re-run
                 write_callback->bytes_written = 0;


### PR DESCRIPTION
This scenario set Transfer-Encoding: chunked + UNSIGNED-PAYLOAD headers which is rejected.

1. Fall back to Content-Length: 0 when toS3CallbackTotalSize < 0 and no xAmzTrailer is set.  This is the normal case for non-chunked encoding.
2. Suppress the creation of x-amz-decoded-content-length header (only needed for chunked encoding) by initializing xAmzDecodedContentLength to -1.  This is only set to a real value when chunked encoding with trailing checksum is used.

Test suite passed with these changes.