### PR TITLE
[2234] Detect objects too large to upload early with better err msgs. (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ S3_DEFAULT_HOSTNAME=s3.<bucket-region>.amazonaws.com
 
 To define S3 provider constraints and control multipart behavior:
 -   `S3_MPU_CHUNK` - This defines the minimum part size allowed (in MB).  The default is 5MB which is the minimum part size defined in AWS.
--   `S3_ENABLE_MPU=0` disables multipart uploads.
--   `S3_MAX_UPLOAD_SIZE_MB` - This defines the maximum upload size for non-multipart uploads (in MB), maximum part size, as well as the maximum size when using the CopyObject API.  The default is 5120MB (5GB).  This setting is ignored if MPU uploads are disabled.
--   `S3_MPU_THREADS` is the number of parts to upload in parallel.
+-   `S3_ENABLE_MPU=0` - Disables multipart uploads.
+-   `S3_MAX_UPLOAD_SIZE_MB` - This defines the maximum upload size for non-multipart uploads (in MB), maximum part size, as well as the maximum size when using the CopyObject API.  The default is 5120 MiB (5 GiB).
+-   `S3_MPU_THREADS` - The number of parts to upload in parallel.
 -   `S3_URI_REQUEST_STYLE` - The path request style used.  This is either "path" or "virtualhost".  The default is "path".  See [path vs virtual hosted requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
 -   `S3_STORAGE_CLASS` - Defines the Glacier storage class used to archive objects. Valid values are "Standard", "Glacier", "Deep_Archive", and "Glacier_IR". The default is "Standard", and these values are not case sensitive. See [Storage Class Intro](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html).
 -   `S3_RESTORATION_DAYS` - The number of days an object is to be restored when restoring from Glacier.  See [RestoreObject API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html).
@@ -148,8 +148,6 @@ Cacheless mode has a few extra configuration parameters in addition to HOST_MODE
 -   `CIRCULAR_BUFFER_TIMEOUT_SECONDS` - The number of seconds the plugin will wait when waiting to read or write data from the circular buffer.  The default is 180s.
 -   `S3_CACHE_DIR` - This is the directory where temporary cache files are located in cases where a cache file is required.  (See below.)  The default is `/tmp`.
 
-Note that with the default values for CIRCULAR_BUFFER_SIZE and S3_MPU_CHUNK, due to the 10,000 part limit in AWS, the largest file that can be uploaded is 20 MiB * 10,000 or roughly 200 GiB.  To upload larger files these defaults need to be updated which will have memory use implications.
-
 The following is an example of how to configure a `cacheless_attached` S3 resource:
 
 ```
@@ -160,6 +158,19 @@ Some configuration settings have special meaning when the resource is in cachele
 -   When S3_ENABLE_MPU = 0, a cache file will be used when the S3 plugin receives parallel uploads from iRODS.
 -   When iRODS is using parallel transfer but each transfer part is less than S3_MPU_CHUNK, a cache file will be used
 -   The S3_MPU_THREADS setting is only used when flushing a cache file to S3.  In streaming mode iRODS controls the number of transfer threads that are used.
+
+#### Handling Very Large Objects
+
+So that part retries can be performed, the part size is limited to the circular buffer size which is CIRCULAR_BUFFER_SIZE * S3_MPU_CHUNK (in MiB). By default this is 4 * 5 MiB = 20 MiB.
+
+The object size must be less than 10,000 times this circular buffer size. Using the defaults that is 20 MiB * 10,000 or roughly 200 GiB. In cases where 10,000 is not evenly divisible by the thread count, the maximum object size will be a little less than this due to the way the bytes are split between parts.
+
+To handle larger objects, the CIRCULAR_BUFFER_SIZE must be increased. Note that the total memory used is the (circular buffer size) * (average number of threads) * (number of simultaneous transfers).
+
+To reduce the amount of memory used:
+
+1. Set up one resource for normal/smaller objects that have a smaller CIRCULAR_BUFFER_SIZE.
+2. Set up another resource for very large objects that have a larger CIRCULAR_BUFFER_SIZE. Scale this to the size needed.
 
 #### Cache Rules When Using Cacheless Mode
 

--- a/packaging/resource_suite_s3_nocache.py
+++ b/packaging/resource_suite_s3_nocache.py
@@ -1816,6 +1816,135 @@ OUTPUT ruleExecOut
             s3plugin_lib.remove_if_exists(file1)
             s3plugin_lib.remove_if_exists(file2)
 
+    def cleanup_failed_put__issue_2234(self, filename):
+        # The part-count check in resolve_hierarchy only has the object's size to work
+        # with. The number of transfer threads is not known until after hierarchy
+        # resolution. Object uploads that fail because of the size and thread count
+        # combination are rejected after the object is locked. This method removes
+        # that lock.
+        logical_path = self.user0.session_collection + '/' + filename
+        self.admin.run_icommand(['iadmin', 'modrepl', 'logical_path', logical_path,
+                'replica_number', '0', 'DATA_REPL_STATUS', '0'])
+        self.user0.run_icommand(['irm', '-f', filename])
+
+    def test_iput_fails_cleanly_when_object_needs_too_many_parts__issue_2234(self):
+        try:
+            hostname = lib.get_hostname()
+            hostuser = getpass.getuser()
+            resource_name = f'{(inspect.currentframe().f_code.co_name)[:58]}_resc'  # resource names must be <= 63 chars
+
+            # With S3_MPU_CHUNK=5 (MB) and CIRCULAR_BUFFER_SIZE=2, the fixed part size used
+            # for streaming multipart uploads is 10 MiB.  AWS S3 multipart uploads are capped
+            # at 10,000 parts, so any object that would need more than 10,000 parts will be rejected.
+            #
+            # When MPU is disabled, any object over the maximum single put size will be rejected.
+            s3_context = self.s3_context + ';S3_MPU_CHUNK=5;CIRCULAR_BUFFER_SIZE=2'
+
+            self.admin.assert_icommand(f'iadmin mkresc {resource_name} s3 {hostname}:/{self.s3bucketname}/{hostuser}/{resource_name} {s3_context}', 'STDOUT_SINGLELINE', 'Creating')
+
+            circular_buffer_size = 5 * 1024 * 1024 * 2  # S3_MPU_CHUNK(5MB) * CIRCULAR_BUFFER_SIZE(2)
+            maximum_number_of_parts = 10000
+
+            # Default S3_MAX_UPLOAD_SIZE_MB is not overridden by s3_context above.
+            max_single_part_upload_size = 5 * 1024 * 1024 * 1024  # 5 GiB
+
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+
+            if self.s3EnableMPU:
+                # One byte larger than the circular buffer size * maximum number of parts.
+                # This needs more than 10,000 parts no matter how the bytes are divided
+                # among threads.
+                file_size = circular_buffer_size * maximum_number_of_parts + 1
+                expected_error = 'S3_PUT_ERROR'
+                expected_message = 'cannot be uploaded via S3 multipart upload'
+            else:
+                # MPU disabled means the object is always uploaded as a single part (one S3
+                # PUT) capped at the maximum single part upload size.
+                file_size = max_single_part_upload_size + 1
+                expected_error = 'UNIX_FILE_OPEN_ERR'
+                expected_message = 'cannot be uploaded via an S3 PutObject'
+
+            s3plugin_lib.truncate_file(file1, file_size)
+
+            # Attempt a file over the maximum allowed size. These have different error codes to match
+            # existing behavior. The descriptive message is pushed onto the RE error stack and
+            # printed to stdout, while the status code shows up on stderr.
+            out, err, rc = self.user0.run_icommand(['iput', '-N', '1', '-f', '-R', resource_name, file1])
+            self.assertNotEqual(0, rc)
+            self.assertIn(expected_error, err)
+            self.assertIn(expected_message, out)
+            # rejected during hierarchy resolution, before any catalog entry was created
+            self.user0.assert_icommand(f'ils -L {file1}', 'STDERR_SINGLELINE', 'does not exist')
+
+        finally:
+            # cleanup
+            self.cleanup_failed_put__issue_2234(file1)
+            self.admin.assert_icommand(f'iadmin rmresc {resource_name}', 'EMPTY')
+            s3plugin_lib.remove_if_exists(file1)
+
+    def test_iput_fails_cleanly_when_thread_split_pushes_object_past_max_parts__issue_2234(self):
+        try:
+            hostname = lib.get_hostname()
+            hostuser = getpass.getuser()
+            resource_name = f'{(inspect.currentframe().f_code.co_name)[:58]}_resc'  # resource names must be <= 63 chars
+
+            s3_context = self.s3_context + ';S3_MPU_CHUNK=5;CIRCULAR_BUFFER_SIZE=2'
+
+            self.admin.assert_icommand(f'iadmin mkresc {resource_name} s3 {hostname}:/{self.s3bucketname}/{hostuser}/{resource_name} {s3_context}', 'STDOUT_SINGLELINE', 'Creating')
+
+            circular_buffer_size = 5 * 1024 * 1024 * 2  # S3_MPU_CHUNK(5MB) * CIRCULAR_BUFFER_SIZE(2)
+            maximum_number_of_parts = 10000
+            number_of_threads = 3
+
+            # With 3 threads, iRODS splits the object so the first two threads each get
+            # floor(object size / 3) bytes and the third (last) thread gets that plus the
+            # remainder.  Because the maximum number of parts (10,000) is not evenly divisible
+            # by 3, the largest object that still fits within the 10,000 part limit at this
+            # part size is 9999*(circular buffer size) + 2 bytes.
+            true_maximum_object_size_for_three_threads = (maximum_number_of_parts - 1) * circular_buffer_size + 2
+            file_size = true_maximum_object_size_for_three_threads + 1
+
+            file1 = f'{inspect.currentframe().f_code.co_name}_f1'
+
+            s3plugin_lib.truncate_file(file1, file_size)
+
+            # When MPU is enabled, this object's size alone does not exceed the part
+            # limit, only the 3-way thread split does. The number of transfer threads
+            # isn't known until after hierarchy resolution (iRODS core computes it via
+            # getNumThreads() but only after the catalog replica is already registered
+            # and locked. The client independently derives a generic SYS_COPY_LEN_ERR
+            # (from a byte-count mismatch) rather than asking the server for the underlying
+            # S3_PUT_ERROR or its message.
+            #
+            # When MPU is disabled, the outcome has nothing to do with thread splitting at
+            # all: the object is also well over the default 5 GiB single-part upload limit,
+            # so the max-upload-size check in resolve_hierarchy rejects it early regardless of -N.
+            # In this case the error is sent back to the client and appears in stdout.
+            if self.s3EnableMPU:
+                expected_error = 'SYS_COPY_LEN_ERR'
+                expected_message = None
+            else:
+                expected_error = 'UNIX_FILE_OPEN_ERR'
+                expected_message = 'cannot be uploaded via an S3 PutObject'
+
+            # The descriptive message (when present) is pushed onto the RE error stack and
+            # printed to stdout, while the status code shows up on stderr.
+            out, err, rc = self.user0.run_icommand(
+                    ['iput', '-N', str(number_of_threads), '-f', '-R', resource_name, file1])
+            self.assertNotEqual(0, rc)
+            self.assertIn(expected_error, err)
+            if expected_message is not None:
+                self.assertIn(expected_message, out)
+
+            if not self.s3EnableMPU:
+                self.user0.assert_icommand(f'ils -L {file1}', 'STDERR_SINGLELINE', 'does not exist')
+
+        finally:
+            # cleanup
+            self.cleanup_failed_put__issue_2234(file1)
+            self.admin.assert_icommand(f'iadmin rmresc {resource_name}', 'EMPTY')
+            s3plugin_lib.remove_if_exists(file1)
+
     def test_rm_without_force(self):
 
         try:

--- a/packaging/s3plugin_lib.py
+++ b/packaging/s3plugin_lib.py
@@ -5,6 +5,10 @@ def remove_if_exists(localfile):
     if os.path.exists(localfile):
         os.unlink(localfile)
 
+def truncate_file(f_name, f_size):
+    with open(f_name, 'wb') as f:
+        f.truncate(f_size)
+
 def make_arbitrary_file(f_name, f_size, buffer_size=32*1024*1024):
     # do not care about true randomness
     random.seed(5)

--- a/s3_resource/src/s3_operations.cpp
+++ b/s3_resource/src/s3_operations.cpp
@@ -573,6 +573,28 @@ namespace irods_s3 {
 
     }
 
+    // Returns the circular buffer size, in bytes for multipart uploads.
+    // Mirrors the reading logic in make_dstream() below.
+    std::int64_t get_circular_buffer_size_in_bytes(irods::plugin_property_map& _prop_map) {
+
+        unsigned int circular_buffer_size = S3_DEFAULT_CIRCULAR_BUFFER_SIZE;
+
+        std::string circular_buffer_size_str;
+        irods::error ret = _prop_map.get<std::string>(s3_circular_buffer_size, circular_buffer_size_str);
+        if (ret.ok()) {
+            try {
+                circular_buffer_size = boost::lexical_cast<unsigned int>(circular_buffer_size_str);
+            } catch (const boost::bad_lexical_cast &) {}
+        }
+
+        // minimum circular buffer size is 2 * minimum_part_size
+        if (circular_buffer_size < 2) {
+            circular_buffer_size = 2;
+        }
+
+        return static_cast<std::int64_t>(circular_buffer_size) * s3GetMPUChunksize(_prop_map);
+    }
+
 
     std::tuple<irods::error, std::shared_ptr<dstream>, std::shared_ptr<s3_transport>> make_dstream(
             irods::plugin_context& _ctx,
@@ -2306,6 +2328,11 @@ namespace irods_s3 {
                         __FILE__, __LINE__, __FUNCTION__, thread_id, data_size_str);
             }
 
+        } else if (file_obj->size() > 0) {
+            // DATA_SIZE_KW is not set in cond_input for a normal iput at hierarchy-resolution
+            // time. The size is still known as it comes from the client's request
+            // (dataObjInp->dataSize) and is already captured on the object pointed to by the file_object_ptr.
+            data_size = static_cast<std::uint64_t>(file_obj->size());
         }
 
         // try to get number of threads from NUM_THREADS_KW
@@ -2363,6 +2390,69 @@ namespace irods_s3 {
         // "sync_to_arch" operation.
         if (!is_cacheless_mode(_ctx.prop_map()) && irods::CREATE_OPERATION == *_opr) {
             return ERROR(SYS_NOT_SUPPORTED, "Create operation not supported for an archive");
+        }
+
+        if ((irods::CREATE_OPERATION == *_opr || irods::WRITE_OPERATION == *_opr) &&
+                data_size > 0 &&
+                data_size != static_cast<std::uint64_t>(s3_transport_config::UNKNOWN_OBJECT_SIZE)) {
+
+            // Reject up front if the object would need more than 10000 parts at the configured
+            // circular buffer size. This check is placed here to reject before a file is
+            // registered and locked.
+            if (s3GetEnableMultiPartUpload(_ctx.prop_map())) {
+
+                // The real number of client transfer threads is not known yet in most cases.
+                // For now just detect whether file size > circular buffer size * 10,000.
+                // If the thread split causes us to use more than 10,000 threads, that is detected later.
+                std::int64_t circular_buffer_size = get_circular_buffer_size_in_bytes(_ctx.prop_map());
+
+                std::int64_t max_object_size_for_part_count =
+                        irods::experimental::io::s3_transport::constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD *
+                        circular_buffer_size;
+
+                if (static_cast<std::int64_t>(data_size) > max_object_size_for_part_count) {
+                    logger::warn("Object [{}] of size [{}] bytes cannot be uploaded via S3 multipart upload. It "
+                            "would require more than [{}] parts at the configured circular buffer size "
+                            "(S3_MPU_CHUNK*CIRCULAR_BUFFER_SIZE) of [{}] bytes. Increase the circular "
+                            "buffer size on resource [{}] to reduce the number of parts required.",
+                            file_obj->logical_path(),
+                            data_size,
+                            irods::experimental::io::s3_transport::constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD,
+                            circular_buffer_size,
+                            get_resource_name(_ctx.prop_map()));
+                    const std::string msg_to_client = fmt::format(
+                            "Object of size [{}] bytes cannot be uploaded via S3 multipart upload "
+                            "with the current configuration.  See the warning message in the iRODS log for more details.",
+                            data_size);
+                    addRErrorMsg(&_ctx.comm()->rError, S3_PUT_ERROR, msg_to_client.c_str());
+                    return ERROR(S3_PUT_ERROR, msg_to_client);
+                }
+
+            // When MPU is disabled, an object is always uploaded as a single S3 PUT which has
+            // a maximum size of S3_MAX_UPLOAD_SIZE_MB (usually 5 GiB).
+            } else {
+
+                std::int64_t max_single_part_upload_size =
+                        s3GetMaxUploadSizeMB(_ctx.prop_map()) * 1024 * 1024;
+
+                if (static_cast<std::int64_t>(data_size) > max_single_part_upload_size) {
+                    logger::warn("Object [{}] of size [{}] bytes cannot be uploaded because S3 multipart upload is "
+                            "disabled and the object is larger than the configured maximum single-part "
+                            "upload size (S3_MAX_UPLOAD_SIZE_MB) of [{}] bytes. Enable multipart upload or "
+                            "increase the maximum upload size on resource [{}] - if the S3 provider allows larger single "
+                            "part uploads - to upload this object.",
+                            file_obj->logical_path(),
+                            data_size,
+                            max_single_part_upload_size,
+                            get_resource_name(_ctx.prop_map()));
+                    const std::string msg_to_client = fmt::format(
+                            "Object of size [{}] bytes cannot be uploaded via an S3 PutObject.  See the warning "
+                            "message in the iRODS log for more details.",
+                            data_size);
+                    addRErrorMsg(&_ctx.comm()->rError, UNIX_FILE_OPEN_ERR, msg_to_client.c_str());
+                    return ERROR(UNIX_FILE_OPEN_ERR, msg_to_client);
+                }
+            }
         }
 
         *_out_vote = irv::vote::zero;

--- a/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
+++ b/s3_transport/include/irods/private/s3_transport/s3_transport.hpp
@@ -778,6 +778,30 @@ namespace irods::experimental::io::s3_transport
             return config_.bytes_this_thread;
         }
 
+        // Computes the total number of multipart-upload parts required to send total_bytes
+        // split across number_of_threads threads, each part at most part_size bytes.  Uses
+        // the same split as determine_start_and_end_part_from_offset_and_bytes_this_thread.
+        // All but the last thread get floor(total_bytes / number_of_threads) bytes, the last
+        // thread gets that plus the remainder.  number_of_threads is clamped to at least 1.
+        static std::int64_t total_number_of_parts_for_object(
+                std::int64_t total_bytes,
+                int number_of_threads,
+                std::int64_t part_size)
+        {
+            if (total_bytes <= 0) {
+                return 0;
+            }
+
+            std::int64_t threads = std::max(1, number_of_threads);
+
+            std::int64_t bytes_per_thread = total_bytes / threads;
+            std::int64_t last_thread_bytes = bytes_per_thread + total_bytes % threads;
+
+            std::int64_t parts_per_thread = (bytes_per_thread + part_size - 1) / part_size;
+            std::int64_t parts_last_thread = (last_thread_bytes + part_size - 1) / part_size;
+
+            return (threads - 1) * parts_per_thread + parts_last_thread;
+        }
 
         // this function uses the starting offset provided to the transport
         // and the number of bytes in this thread to determine the start and end
@@ -1362,6 +1386,27 @@ namespace irods::experimental::io::s3_transport
             if (!config_.multipart_enabled && config_.object_size > config_.max_single_part_upload_size) {
                 this->set_error(ERROR(UNIX_FILE_OPEN_ERR, "File can't be uploaded because MPU is disabled and "
                     "file size is greater than maximum part size"));
+                return false;
+            }
+
+            // For the streaming (non-cache) multipart path, part size is fixed at
+            // the circular buffer size.  If the object needs more than 10000 parts,
+            // the open needs to be rejected.
+            if (!use_cache_ && config_.multipart_enabled &&
+                    total_number_of_parts_for_object(config_.object_size,
+                            config_.number_of_client_transfer_threads,
+                            static_cast<std::int64_t>(config_.circular_buffer_size))
+                        > constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD) {
+                this->set_error(ERROR(S3_PUT_ERROR, fmt::format(
+                        "Object [{}] of size [{}] bytes cannot be uploaded via S3 multipart upload. It would "
+                        "require more than [{}] parts at the configured circular buffer size "
+                        "(S3_MPU_CHUNK*CIRCULAR_BUFFER_SIZE) of [{}] bytes. Increase the circular buffer "
+                        "size on resoure [{}] to reduce the number of parts required.",
+                        object_key_,
+                        config_.object_size,
+                        constants::MAXIMUM_NUMBER_ETAGS_PER_UPLOAD,
+                        config_.circular_buffer_size,
+                        config_.resource_name)));
                 return false;
             }
 

--- a/s3_transport/include/irods/private/s3_transport/util.hpp
+++ b/s3_transport/include/irods/private/s3_transport/util.hpp
@@ -49,10 +49,10 @@ namespace irods::experimental::io::s3_transport
     struct constants
     {
 
-        static const std::int64_t            MAXIMUM_NUMBER_ETAGS_PER_UPLOAD{10000};
-        static const std::int64_t            BYTES_PER_ETAG{112};  // 80 bytes for every string added, 32 bytes for the vector size,
+        static constexpr std::int64_t        MAXIMUM_NUMBER_ETAGS_PER_UPLOAD{10000};
+        static constexpr std::int64_t        BYTES_PER_ETAG{112};  // 80 bytes for every string added, 32 bytes for the vector size,
                                                               // determined by testing
-        static const std::int64_t            UPLOAD_ID_SIZE{128};
+        static constexpr std::int64_t        UPLOAD_ID_SIZE{128};
 
         // See https://groups.google.com/g/boost-list/c/5ADnEPYg-ho for an explanation
         // of why the 100*sizeof(void*) is used below.  Essentially, the shared memory


### PR DESCRIPTION
1. Add a section in the README for best practices around handling very large files.
2. Handle large files early in resolve_resource_hierarchy prior to the object being locked.
3. Since thread count is not known during resolve_resource_hierarchy, detect files that are only too big because of byte splitting per thread in open(). This is after the object has been locked and for the multithreaded case the explicit error is not passed back to the client.
4. When MPU uploads are disabled, use the maximum single part upload file limit in these checks.